### PR TITLE
Interface refinements for transports.

### DIFF
--- a/autobahn/wamp_transport.hpp
+++ b/autobahn/wamp_transport.hpp
@@ -42,6 +42,20 @@ class wamp_transport
 {
 public:
     /*!
+     * Handler to invoke when pausing transport transmission.
+     */
+    using pause_handler = std::function<void()>;
+
+    /*!
+     * Handler to invoke when resuming transport transmission.
+     */
+    using resume_handler = std::function<void()>;
+
+public:
+    /*
+     * CONNECTION INTERFACE
+     */
+    /*!
      * Attempts to connect the transport.
      *
      * @return A future that will be satisfied when the connect attempt
@@ -63,6 +77,50 @@ public:
      * @return Whether or not the transport is connected.
      */
     virtual bool is_connected() const = 0;
+
+    /*
+     * SENDER INTERFACE
+     */
+    /*!
+     * Send the message synchronously over the transport.
+     *
+     * @param message The message to be sent.
+     */
+    virtual void send(const std::shared_ptr<wamp_message>& message) = 0;
+
+    /*!
+     * Set the handler to be invoked when the transport detects congestion
+     * sending to the remote peer and needs to apply backpressure on the
+     * application.
+     *
+     * @param handler The pause handler to be invoked.
+     */
+    virtual void set_pause_handler(const pause_handler& handler) = 0;
+
+    /*!
+     * Set the handler to be invoked when the transport detects congestion
+     * has subsided on the remote peer and the application can resume sending
+     * messages.
+     *
+     * @param handler The resume handler to be invoked.
+     */
+    virtual void set_resume_handler(const resume_handler& handler) = 0;
+
+    /*
+     * RECEIVER INTERFACE
+     */
+    /*!
+     * Pause receiving of messages. This will prevent the transport from receiving
+     * any more messages until it has been resumed. This is used to excert
+     * backpressure on the sending peer.
+     */
+    virtual void pause() = 0;
+
+    /*!
+     * Resume receiving of messages. The transport will now begin receiving messsages
+     * again and lift backpressure from the sending peer.
+     */
+    virtual void resume() = 0;
 
     /*!
      * Attaches a handler to the transport. Only one handler may
@@ -90,13 +148,6 @@ public:
      * @return Whether or not a handler is attached.
      */
     virtual bool has_handler() const = 0;
-
-    /*!
-     * Send the message synchronously over the transport.
-     *
-     * @param message The message to be sent.
-     */
-    virtual void send(const std::shared_ptr<wamp_message>& message) = 0;
 
     /*!
      * Default virtual destructor.


### PR DESCRIPTION
As per our conversation on #54 I have updated the interfaces. Not if you still want to go with the `wamp_transport_handler` so I left that part of the interface intact and did not incorporate 'wamp_transport::on_message` or the `message_handler`.