### PR TITLE
Fix unused variables error in build

### DIFF
--- a/autobahn/wamp_auth_utils.hpp
+++ b/autobahn/wamp_auth_utils.hpp
@@ -82,11 +82,11 @@ inline std::string base_64_encode(const std::string & data )
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
 
     BIO_write(bio, (const unsigned char *) data.c_str(), data.size());
-    BIO_flush(bio);
-
+    (void)BIO_flush(bio);
+    
     BIO_get_mem_ptr(bio, &pBuf);
-    BIO_set_close(bio, BIO_NOCLOSE);
-
+    (void)BIO_set_close(bio, BIO_NOCLOSE);
+    
     std::string str_out;
     str_out.assign( pBuf->data, pBuf->length );
 

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -679,7 +679,6 @@ void wamp_session<IStream, OStream>::process_challenge(const wamp_message& messa
 
         std::string challenge, salt;
         int iterations = 0 , keylen = 0;
-        bool salted = false;
 
         // parse the details, and fill variables above
         try {
@@ -695,7 +694,6 @@ void wamp_session<IStream, OStream>::process_challenge(const wamp_message& messa
             itr = details.find("salt");
             if (itr != details.end()) {
                 // ok we must salt our secret
-                salted = true;
                 salt = itr->second.as<std::string>();
 
                 itr = details.find("iterations");


### PR DESCRIPTION
Build was failing for me due to complaints about unused variables.