### PR TITLE
Fix invalid type conversion in publish example

### DIFF
--- a/examples/subscriber.cpp
+++ b/examples/subscriber.cpp
@@ -38,7 +38,7 @@
 
 void topic1(const autobahn::wamp_event& event)
 {
-    std::cerr << "received event: " << event.argument<uint64_t>(0) << std::endl;
+    std::cerr << "received event: " << event.argument<std::string>(0) << std::endl;
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The publish example was not working correctly because
the the subscriber was trying to receive the event
argument as an integer instead of a as a string.

Resolves: #64 #80