### PR TITLE
add process_abort function

### DIFF
--- a/autobahn/exceptions.hpp
+++ b/autobahn/exceptions.hpp
@@ -46,6 +46,11 @@ class no_session_error : public std::runtime_error {
      no_session_error() : std::runtime_error("session not joined") {};
 };
 
+class abort_error : public std::runtime_error {
+  public:
+     abort_error(const std::string& message) : std::runtime_error(message) {};
+};
+
 } // namespace autobahn
 
 #endif // AUTOBAHN_EXCEPTIONS_HPP

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -240,6 +240,9 @@ private:
     /// Process a WAMP HELLO message.
     void process_welcome(const wamp_message& message);
 
+    /// Process a WAMP ABORT message.
+    void process_abort(const wamp_message& message);
+
     /// Process a WAMP CHALLENGE message.
     void process_challenge(const wamp_message& message);
 


### PR DESCRIPTION
I did not have the total overview of how to handle the "details dict" along with an abort ( is it always string -> string mapping ?? ). 

So with those changes here, I took the very conservative road - only adding the URI to the exception raised.  