### PR TITLE
Add missing subscribe options files to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ set(PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_transport_handler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_session.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_session.ipp
+    ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_subscribe_options.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_subscribe_options.ipp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_subscribe_request.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_subscribe_request.ipp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_subscription.hpp


### PR DESCRIPTION
Looks like these files were not previously added to CMakeLists.txt which was causing build failures for 3rd-party projects.