### PR TITLE
Improve debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_message.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_message.ipp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_message_type.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_message_type.ipp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_procedure.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_publication.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/wamp_publication.ipp

--- a/autobahn/wamp_message.hpp
+++ b/autobahn/wamp_message.hpp
@@ -173,6 +173,9 @@ private:
     message_fields m_fields;
 };
 
+/// Convenience operator for outputting a raw wamp message.
+std::ostream& operator<<(std::ostream& os, const wamp_message& message);
+
 } // namespace autobahn
 
 #include "wamp_message.ipp"

--- a/autobahn/wamp_message.ipp
+++ b/autobahn/wamp_message.ipp
@@ -28,6 +28,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "wamp_message_type.hpp"
+
 #include <stdexcept>
 
 namespace autobahn {
@@ -119,6 +121,32 @@ inline wamp_message::message_fields&& wamp_message::fields()
 inline msgpack::zone&& wamp_message::zone()
 {
     return std::move(m_zone);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const wamp_message& message)
+{
+    std::size_t num_fields = message.size();
+    if (num_fields == 0) {
+        os << "unknown []";
+        return os;
+    }
+
+    const msgpack::object& type_field = message.field(0);
+    message_type type = static_cast<message_type>(type_field.as<int>());
+
+    if (num_fields == 1) {
+        os << to_string(type) << " []";
+        return os;
+    }
+
+    os << to_string(type) << " [";
+    os << message.field(1);
+    for (std::size_t index = 2; index < num_fields; ++index) {
+        os << ", " <<  message.field(index);
+    }
+    os << "]";
+
+    return os;
 }
 
 } // namespace autobahn

--- a/autobahn/wamp_message_type.ipp
+++ b/autobahn/wamp_message_type.ipp
@@ -28,56 +28,44 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef AUTOBAHN_WAMP_MESSAGE_TYPE_HPP
-#define AUTOBAHN_WAMP_MESSAGE_TYPE_HPP
-
-#include <string>
-
-#ifdef ERROR
-#undef ERROR
-#endif
-
-#ifdef REGISTERED
-#undef REGISTERED
-#endif
-
 namespace autobahn {
 
-/// WAMP message types.
-enum class message_type : int
+inline std::string to_string(message_type type)
 {
-    HELLO = 1,
-    WELCOME = 2,
-    ABORT = 3,
-    CHALLENGE = 4,
-    AUTHENTICATE = 5,
-    GOODBYE = 6,
-    HEARTBEAT = 7,
-    ERROR = 8,
-    PUBLISH = 16,
-    PUBLISHED = 17,
-    SUBSCRIBE = 32,
-    SUBSCRIBED = 33,
-    UNSUBSCRIBE = 34,
-    UNSUBSCRIBED = 35,
-    EVENT = 36,
-    CALL = 48,
-    CANCEL = 49,
-    RESULT = 50,
-    REGISTER = 64,
-    REGISTERED = 65,
-    UNREGISTER = 66,
-    UNREGISTERED = 67,
-    INVOCATION = 68,
-    INTERRUPT = 69,
-    YIELD = 70
-};
+    static std::map<message_type, std::string> type_names = {
+        { message_type::HELLO, "hello" },
+        { message_type::WELCOME, "welcome" },
+        { message_type::ABORT, "abort" },
+        { message_type::CHALLENGE, "challenge" },
+        { message_type::AUTHENTICATE, "authenticate" },
+        { message_type::GOODBYE, "goodbye" },
+        { message_type::HEARTBEAT, "heartbeat" },
+        { message_type::ERROR, "error" },
+        { message_type::PUBLISH, "publish" },
+        { message_type::PUBLISHED, "published" },
+        { message_type::SUBSCRIBE, "subscribe" },
+        { message_type::SUBSCRIBED, "subscribed" },
+        { message_type::UNSUBSCRIBE, "unsubscribe" },
+        { message_type::UNSUBSCRIBED, "unsubscribed" },
+        { message_type::EVENT, "event" },
+        { message_type::CALL, "call" },
+        { message_type::CANCEL, "cancel" },
+        { message_type::RESULT, "result" },
+        { message_type::REGISTER, "register" },
+        { message_type::REGISTERED, "registered" },
+        { message_type::UNREGISTER, "unregister" },
+        { message_type::UNREGISTERED, "unregistered" },
+        { message_type::INVOCATION, "invocation" },
+        { message_type::INTERRUPT, "interrupt" },
+        { message_type::YIELD, "yield" }
+    };
 
-/// Convert message type enum to human readable string.
-std::string to_string(message_type type);
+    auto result = type_names.find(type);
+    if (result == type_names.end()) {
+        return std::string("unknown");
+    }
+
+    return result->second;
+}
 
 } // namespace autobahn
-
-#include "wamp_message_type.ipp"
-
-#endif // AUTOBAHN_WAMP_MESSAGE_TYPE_HPP

--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -154,6 +154,7 @@ void wamp_rawsocket_transport<Socket>::send_message(wamp_message&& message)
 
     if (m_debug_enabled) {
         std::cerr << "TX message (" << buffer->size() << " octets) ..." << std::endl;
+        std::cerr << "TX message: " << message << std::endl;
     }
 }
 
@@ -349,16 +350,18 @@ void wamp_rawsocket_transport<Socket>::receive_message_body(
         msgpack::unpacked result;
 
         while (m_message_unpacker.next(&result)) {
-            if (m_debug_enabled) {
-                std::cerr << "RX WAMP message: " << result.get() << std::endl;
-            }
-
             wamp_message::message_fields fields;
             result.get().convert(fields);
 
             wamp_message message(std::move(fields), std::move(*(result.zone())));
+            if (m_debug_enabled) {
+                std::cerr << "RX message: " << message << std::endl;
+            }
+
             m_handler->on_message(std::move(message));
         }
+    } else {
+        std::cerr << "RX message ignored: no handler attached" << std::endl;
     }
 
     receive_message();

--- a/examples/callee.cpp
+++ b/examples/callee.cpp
@@ -58,10 +58,11 @@ int main(int argc, char** argv)
         std::cerr << "Connecting to realm: " << parameters->realm() << std::endl;
 
         boost::asio::io_service io;
-        auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
-                io, parameters->rawsocket_endpoint(), true);
-
         bool debug = parameters->debug();
+
+        auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
+                io, parameters->rawsocket_endpoint(), debug);
+
         auto session = std::make_shared<autobahn::wamp_session>(io, debug);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));

--- a/examples/caller.cpp
+++ b/examples/caller.cpp
@@ -47,10 +47,10 @@ int main(int argc, char** argv)
         auto parameters = get_parameters(argc, argv);
 
         boost::asio::io_service io;
-        auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
-                io, parameters->rawsocket_endpoint());
-
         bool debug = parameters->debug();
+        auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
+                io, parameters->rawsocket_endpoint(), debug);
+
         auto session = std::make_shared<autobahn::wamp_session>(io, debug);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));

--- a/examples/publisher.cpp
+++ b/examples/publisher.cpp
@@ -47,12 +47,13 @@ int main(int argc, char** argv)
         auto parameters = get_parameters(argc, argv);
 
         boost::asio::io_service io;
+        bool debug = parameters->debug();
+
         auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
-                io, parameters->rawsocket_endpoint(), true);
+                io, parameters->rawsocket_endpoint(), debug);
 
         // create a WAMP session that talks WAMP-RawSocket over TCP
         //
-        bool debug = parameters->debug();
         auto session = std::make_shared<autobahn::wamp_session>(io, debug);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));

--- a/examples/subscriber.cpp
+++ b/examples/subscriber.cpp
@@ -51,12 +51,13 @@ int main(int argc, char** argv)
         std::cerr << "Connecting to realm: " << parameters->realm() << std::endl;
 
         boost::asio::io_service io;
+        bool debug = parameters->debug();
+
         auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
-                io, parameters->rawsocket_endpoint(), true);
+                io, parameters->rawsocket_endpoint(), debug);
 
         // create a WAMP session that talks WAMP-RawSocket over TCP
         //
-        bool debug = parameters->debug();
         auto session = std::make_shared<autobahn::wamp_session>(io, debug);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));

--- a/examples/uds.cpp
+++ b/examples/uds.cpp
@@ -47,10 +47,11 @@ int main(int argc, char** argv)
         auto parameters = get_parameters(argc, argv);
 
         boost::asio::io_service io;
-        auto transport = std::make_shared<autobahn::wamp_uds_transport>(
-                io, parameters->uds_endpoint());
-
         bool debug = parameters->debug();
+
+        auto transport = std::make_shared<autobahn::wamp_uds_transport>(
+                io, parameters->uds_endpoint(), debug);
+
         auto session = std::make_shared<autobahn::wamp_session>(io, debug);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));

--- a/examples/wampcra.cpp
+++ b/examples/wampcra.cpp
@@ -70,12 +70,13 @@ int main(int argc, char** argv)
         auto parameters = get_parameters(argc, argv);
 
         boost::asio::io_service io;
+        bool debug = parameters->debug();
+
         auto transport = std::make_shared<autobahn::wamp_tcp_transport>(
-                io, parameters->rawsocket_endpoint());
+                io, parameters->rawsocket_endpoint(), debug);
 
         std::string secret = "secret123";
 
-        bool debug = parameters->debug();
         auto session = std::make_shared<auth_wamp_session>(io, debug, secret);
 
         transport->attach(std::static_pointer_cast<autobahn::wamp_transport_handler>(session));


### PR DESCRIPTION
This commit cleans up debugging in the examples to correctly honor the
debug parameter and adds additional debugging for dumping messages
when sending and receiving.

Related: #98