### PR TITLE
Feature/progressive calls

### DIFF
--- a/autobahn/wamp_auth_utils.hpp
+++ b/autobahn/wamp_auth_utils.hpp
@@ -110,7 +110,7 @@ inline std::string derive_key(
         const std::string & salt,
         int iterations,
         int keylen
-		)
+        )
 {
 
     int passwdLen = passwd.size();
@@ -127,19 +127,19 @@ inline std::string derive_key(
 
 
     int result = PKCS5_PBKDF2_HMAC(
-		    pwd, passwdLen,
-		    salt_value, saltLen,
-		    iterations,
-		    EVP_sha256(),
-		    keylen, out);
+            pwd, passwdLen,
+            salt_value, saltLen,
+            iterations,
+            EVP_sha256(),
+            keylen, out);
 
     if ( result != 0 )
     {
-	    return base_64_encode( str_out );
+        return base_64_encode( str_out );
     }
     else
     {
-	    throw derived_key_error();
+        throw derived_key_error();
     }
 }
 

--- a/autobahn/wamp_event.hpp
+++ b/autobahn/wamp_event.hpp
@@ -45,11 +45,11 @@ public:
     wamp_event(msgpack::zone&& zone);
 
 
-	//add URI and details
-	/*!
-	* Event URI.  Used by prefix & wildcard subscriptions
-	*/
-	const std::string& uri() const;
+    //add URI and details
+    /*!
+    * Event URI.  Used by prefix & wildcard subscriptions
+    */
+    const std::string& uri() const;
 
     /*!
      * The number of positional arguments published by the event.
@@ -193,13 +193,13 @@ public:
 
     void set_arguments(const msgpack::object& arguments);
     void set_kw_arguments(const msgpack::object& kw_arguments);
-	void set_details(const msgpack::object& details);
+    void set_details(const msgpack::object& details);
 
 private:
     msgpack::zone m_zone;
     msgpack::object m_arguments;
     msgpack::object m_kw_arguments;
-	std::string m_uri;
+    std::string m_uri;
 
 };
 

--- a/autobahn/wamp_invocation.hpp
+++ b/autobahn/wamp_invocation.hpp
@@ -49,11 +49,11 @@ public:
     wamp_invocation_impl();
     wamp_invocation_impl(wamp_invocation_impl&&) = delete; // copy wamp_invocation instead
 
-	//add URI and details
-	/*!
-	* Invocatition procedure URI.  Used by prefix & wildcard registered procedures
-	*/
-	const std::string& uri() const;
+    //add URI and details
+    /*!
+    * Invocatition procedure URI.  Used by prefix & wildcard registered procedures
+    */
+    const std::string& uri() const;
     /*!
      * The number of positional arguments passed to the invocation.
      */
@@ -202,16 +202,28 @@ public:
     void empty_result();
 
     /*!
+    * Send progressive/partial result with positional arguments.
+    */
+    template <typename List>
+    void progress(const List& arguments);
+
+    /*!
+    * Send progressive/partial result with positional and keyword arguments.
+    */
+    template <typename List, typename Map>
+    void progress(const List& arguments, const Map& kw_arguments);
+
+    /*!
      * Reply to the invocation with positional arguments.
      */
     template <typename List>
-    void result(const List& arguments, bool intermediate = false);
+    void result(const List& arguments);
 
     /*!
      * Reply to the invocation with positional and keyword arguments.
      */
     template <typename List, typename Map>
-    void result(const List& arguments, const Map& kw_arguments, bool intermediate = false);
+    void result(const List& arguments, const Map& kw_arguments);
 
     /*!
      * Reply to the invocation with an error and no further details.
@@ -235,19 +247,31 @@ public:
     //
     // functions only called internally by wamp_session
 
+    using result_type = enum {
+        final = 0,
+        intermediary
+    } ;
+
     using send_result_fn = std::function<void(const std::shared_ptr<wamp_message>&)>;
     void set_send_result_fn(send_result_fn&&);
-	void set_details(const msgpack::object& details);
-	void set_request_id(std::uint64_t);
+    void set_details(const msgpack::object& details);
+    void set_request_id(std::uint64_t);
     void set_zone(msgpack::zone&&);
     void set_arguments(const msgpack::object& arguments);
     void set_kw_arguments(const msgpack::object& kw_arguments);
     bool sendable() const;
 
 private:
-    void throw_if_not_sendable();
+    void throw_if_not_sendable() const;
 
+    template <typename List>
+    void send_result(const List& arguments, result_type resultType);
+
+    template <typename List, typename Map>
+    void send_result(const List& arguments, const Map& kw_arguments, result_type resultType);
 private:
+
+
     msgpack::zone m_zone;
     msgpack::object m_arguments;
     msgpack::object m_kw_arguments;

--- a/autobahn/wamp_invocation.hpp
+++ b/autobahn/wamp_invocation.hpp
@@ -192,6 +192,11 @@ public:
     void get_kw_arguments(Map& kw_args) const;
 
     /*!
+    * Checks if caller expects progressive results.
+    */
+    bool progressive_results_expected() const;
+
+    /*!
      * Reply to the invocation with an empty result.
      */
     void empty_result();
@@ -200,13 +205,13 @@ public:
      * Reply to the invocation with positional arguments.
      */
     template <typename List>
-    void result(const List& arguments);
+    void result(const List& arguments, bool intermediate = false);
 
     /*!
      * Reply to the invocation with positional and keyword arguments.
      */
     template <typename List, typename Map>
-    void result(const List& arguments, const Map& kw_arguments);
+    void result(const List& arguments, const Map& kw_arguments, bool intermediate = false);
 
     /*!
      * Reply to the invocation with an error and no further details.
@@ -249,6 +254,7 @@ private:
     send_result_fn m_send_result_fn;
     std::uint64_t m_request_id;
     std::string m_uri;
+    bool m_progressive_results_expected;
 };
 
 using wamp_invocation = std::shared_ptr<wamp_invocation_impl>;

--- a/examples/callee.cpp
+++ b/examples/callee.cpp
@@ -60,7 +60,7 @@ void longop(autobahn::wamp_invocation invocation)
         boost::this_thread::sleep(boost::posix_time::milliseconds(3000));
         if (i < a)
         {
-            invocation->result(std::make_tuple(i), true);
+            invocation->progress(std::make_tuple(i));
         }
     }
     invocation->result(std::make_tuple(i));

--- a/examples/parameters.cpp
+++ b/examples/parameters.cpp
@@ -49,7 +49,7 @@ parameters::parameters()
     , m_realm(DEFAULT_REALM)
     , m_rawsocket_endpoint(LOCALHOST_IP_ADDRESS, DEFAULT_RAWSOCKET_PORT)
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-	, m_uds_endpoint(DEFAULT_UDS_PATH)
+    , m_uds_endpoint(DEFAULT_UDS_PATH)
 #endif
 {
 }

--- a/examples/parameters.hpp
+++ b/examples/parameters.hpp
@@ -33,7 +33,7 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-#	include <boost/asio/local/stream_protocol.hpp>
+#    include <boost/asio/local/stream_protocol.hpp>
 #endif 
 #include <cstdint>
 #include <string>
@@ -48,8 +48,8 @@ public:
     const boost::asio::ip::tcp::endpoint& rawsocket_endpoint() const;
 
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-	void set_uds_endpoint(const std::string& path);
-	const boost::asio::local::stream_protocol::endpoint& uds_endpoint() const;
+    void set_uds_endpoint(const std::string& path);
+    const boost::asio::local::stream_protocol::endpoint& uds_endpoint() const;
 #endif
 
     void set_debug(bool enabled);
@@ -60,7 +60,7 @@ private:
     std::string m_realm;
     boost::asio::ip::tcp::endpoint m_rawsocket_endpoint;
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-	boost::asio::local::stream_protocol::endpoint m_uds_endpoint;
+    boost::asio::local::stream_protocol::endpoint m_uds_endpoint;
 #endif
 };
 

--- a/examples/provide_prefix.cpp
+++ b/examples/provide_prefix.cpp
@@ -48,25 +48,25 @@ void calculator(autobahn::wamp_invocation invocation)
 
     std::cerr << "Procedure " << invocation->uri() << "invoked: " << a << ", " << b << std::endl;
 
-	auto suffix = invocation->uri().substr(PREFIX.size());
+    auto suffix = invocation->uri().substr(PREFIX.size());
 
-	if (suffix == ".add")
-	{
-		invocation->result(std::make_tuple(a + b));
-	}
-	else if (suffix == ".mul2")
-	{
-		invocation->result(std::make_tuple(a * b));
-	}
-	else
-	{
+    if (suffix == ".add")
+    {
+        invocation->result(std::make_tuple(a + b));
+    }
+    else if (suffix == ".mul2")
+    {
+        invocation->result(std::make_tuple(a * b));
+    }
+    else
+    {
                 throw std::runtime_error("procedure not implemented " + invocation->uri());
-	}
+    }
 }
 
 void on_topic(const autobahn::wamp_event& event)
 {
-	std::cerr << "received event: " << event.uri() << " with argument " << event.argument<std::string>(0) << std::endl;
+    std::cerr << "received event: " << event.uri() << " with argument " << event.argument<std::string>(0) << std::endl;
 }
 
 int main(int argc, char** argv)
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
         boost::future<void> start_future;
         boost::future<void> join_future;
         boost::future<void> provide_future;
-		boost::future<void> subscribe_future;
+        boost::future<void> subscribe_future;
 
         connect_future = transport->connect().then([&](boost::future<void> connected) {
             try {
@@ -127,8 +127,8 @@ int main(int argc, char** argv)
                         io.stop();
                         return;
                     }
-					provide_future = session->provide(PREFIX, &calculator, { { "match", msgpack::object("prefix") } }).then(
-						[&](boost::future<autobahn::wamp_registration> registration) {
+                    provide_future = session->provide(PREFIX, &calculator, { { "match", msgpack::object("prefix") } }).then(
+                        [&](boost::future<autobahn::wamp_registration> registration) {
                         try {
                             std::cerr << "registered procedure:" << registration.get().id() << std::endl;
                         } catch (const std::exception& e) {
@@ -138,19 +138,19 @@ int main(int argc, char** argv)
                         }
                     });
 
-					subscribe_future = session->subscribe("com.examples.subscriptions", &on_topic, autobahn::wamp_subscribe_options("prefix")).then([&](boost::future<autobahn::wamp_subscription> subscribed)
-					{
-						try {
+                    subscribe_future = session->subscribe("com.examples.subscriptions", &on_topic, autobahn::wamp_subscribe_options("prefix")).then([&](boost::future<autobahn::wamp_subscription> subscribed)
+                    {
+                        try {
 
-							std::cerr << "subscribed to topic: " << subscribed.get().id() << std::endl;
-						}
-						catch (const std::exception& e) {
-							std::cerr << e.what() << std::endl;
-							io.stop();
-							return;
-						}
+                            std::cerr << "subscribed to topic: " << subscribed.get().id() << std::endl;
+                        }
+                        catch (const std::exception& e) {
+                            std::cerr << e.what() << std::endl;
+                            io.stop();
+                            return;
+                        }
 
-					});
+                    });
                 });
             });
         });

--- a/examples/subscriber.cpp
+++ b/examples/subscriber.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv)
         boost::future<void> connect_future;
         boost::future<void> start_future;
         boost::future<void> join_future;
-		boost::future<void> subscribe_future;
+        boost::future<void> subscribe_future;
         connect_future = transport->connect().then([&](boost::future<void> connected) {
             try {
                 connected.get();
@@ -104,17 +104,17 @@ int main(int argc, char** argv)
 
                     subscribe_future = session->subscribe("com.examples.subscriptions.topic1", &on_topic1).then([&] (boost::future<autobahn::wamp_subscription> subscribed)
                     {
-						try {
-							
-							std::cerr << "subscribed to topic: " << subscribed.get().id() << std::endl;
-						}
-						catch (const std::exception& e) {
-							std::cerr << e.what() << std::endl;
-							io.stop();
-							return;
-						}
+                        try {
+                            
+                            std::cerr << "subscribed to topic: " << subscribed.get().id() << std::endl;
+                        }
+                        catch (const std::exception& e) {
+                            std::cerr << e.what() << std::endl;
+                            io.stop();
+                            return;
+                        }
 
-					});
+                    });
 
 
                 });

--- a/examples/wampcra.cpp
+++ b/examples/wampcra.cpp
@@ -38,22 +38,22 @@
 
 void calculator(autobahn::wamp_invocation invocation)
 {
-	auto a = invocation->argument<uint64_t>(0);
-	auto b = invocation->argument<uint64_t>(1);
+    auto a = invocation->argument<uint64_t>(0);
+    auto b = invocation->argument<uint64_t>(1);
 
-	std::cerr << "Procedure com.examples.calculator.add2 invoked: " << a << ", " << b << std::endl;
+    std::cerr << "Procedure com.examples.calculator.add2 invoked: " << a << ", " << b << std::endl;
 
-	invocation->result(std::make_tuple(a + b));
+    invocation->result(std::make_tuple(a + b));
 }
 
 void math(autobahn::wamp_invocation invocation)
 {
-	auto a = invocation->argument<uint64_t>(0);
-	auto b = invocation->argument<uint64_t>(1);
+    auto a = invocation->argument<uint64_t>(0);
+    auto b = invocation->argument<uint64_t>(1);
 
-	std::cerr << "Procedure com.examples.calculator.add2 invoked: " << a << ", " << b << std::endl;
+    std::cerr << "Procedure com.examples.calculator.add2 invoked: " << a << ", " << b << std::endl;
 
-	invocation->result(std::make_tuple(a + b));
+    invocation->result(std::make_tuple(a + b));
 }
 
 class auth_wamp_session :
@@ -111,8 +111,8 @@ int main(int argc, char** argv)
         boost::future<void> join_future;
         boost::future<void> leave_future;
         boost::future<void> stop_future;
-		boost::future<void> provide_future;
-		boost::future<void> prefix_provide_future;
+        boost::future<void> provide_future;
+        boost::future<void> prefix_provide_future;
 
         connect_future = transport->connect().then([&](boost::future<void> connected) {
             try {
@@ -136,31 +136,31 @@ int main(int argc, char** argv)
                 std::string authid = "homer";
                 std::vector<std::string> authmethods = { "wampcra" };
                 join_future = session->join(parameters->realm(), authmethods, authid).then([&](boost::future<uint64_t> joined) {
-					try {
-						std::cerr << "joined realm: " << joined.get() << std::endl;
+                    try {
+                        std::cerr << "joined realm: " << joined.get() << std::endl;
 
 
 
-						leave_future = session->leave().then([&](boost::future<std::string> reason) {
-							try {
-								std::cerr << "left session (" << reason.get() << ")" << std::endl;
-							}
-							catch (const std::exception& e) {
-								std::cerr << "failed to leave session: " << e.what() << std::endl;
-								io.stop();
-								return;
-							}
+                        leave_future = session->leave().then([&](boost::future<std::string> reason) {
+                            try {
+                                std::cerr << "left session (" << reason.get() << ")" << std::endl;
+                            }
+                            catch (const std::exception& e) {
+                                std::cerr << "failed to leave session: " << e.what() << std::endl;
+                                io.stop();
+                                return;
+                            }
 
-							stop_future = session->stop().then([&](boost::future<void> stopped) {
-								std::cerr << "stopped session" << std::endl;
-								io.stop();
-							});
-						});
+                            stop_future = session->stop().then([&](boost::future<void> stopped) {
+                                std::cerr << "stopped session" << std::endl;
+                                io.stop();
+                            });
+                        });
 
 
 
-					}
-					catch (const std::exception& e) {
+                    }
+                    catch (const std::exception& e) {
                         std::cerr << e.what() << std::endl;
                         io.stop();
                         return;

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -31,6 +31,17 @@
                }
             );
 
+            session.call('com.myapp.longop', [3], {}, { receive_progress: true }).then(
+                  function (res) {
+                      console.log("Final:", res);
+                      connection.close();
+                  },
+                  function (err) {
+                  },
+                  function (progress) {
+                      console.log("Progress:", progress);
+                  }
+               );
          };
 
          connection.onclose = function (reason, details) {


### PR DESCRIPTION
Callee Progressive results #102

To test: start calee example and open index.html served by crossbar.  Observe JS console.  Progressive call results should appear 3 seconds apart, followed by single "Final" result.

```
Progress: 0
Progress: 1
Progress: 2
Final: 3
```
Last commit addresses concern about public interface lack of explicitness. (Re: @jpetso ) 

`progress()` and `result()` are separate calls now
Removed tabs #104 and 