### PR TITLE
Save WELCOME message Details dictionary

### DIFF
--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -249,6 +249,8 @@ public:
      */
     virtual boost::future<wamp_authenticate> on_challenge(const wamp_challenge& challenge);
 
+    const std::unordered_map<std::string, msgpack::object>& welcome_details();
+
 private:
     // Implements the wamp transport handler interface.
     virtual void on_attach(const std::shared_ptr<wamp_transport>& transport) override;
@@ -333,6 +335,10 @@ private:
 
     // Map of registered procedures (registration ID -> procedure)
     std::map<uint64_t, wamp_procedure> m_procedures;
+
+    // Welcome details
+    std::unordered_map<std::string, msgpack::object> m_welcome_details;
+
 };
 
 } // namespace autobahn

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -249,6 +249,38 @@ public:
      */
     virtual boost::future<wamp_authenticate> on_challenge(const wamp_challenge& challenge);
 
+    /*!
+    * Accessor method to WELCOME DETAILS dictionary containing router roles 
+    * and corresponding features, authid, authrole, ...)
+    *
+    *
+    * \return A dictionary of objects received with WELCOME message upon joining.
+    * i.e.
+    * {
+    *   "realm": "<string>",
+    *   "authprovider": "dynamic",
+    *   "roles": {
+    *     "broker": {
+    *       "features": {
+    *         "publisher_identification": true,
+    *         "pattern_based_subscription": true,
+    *         ...
+    *       }
+    *     },
+    *     "dealer": {
+    *       "features": {
+    *         "pattern_based_registration": true,
+    *         "progressive_call_results": true,
+    *          ...
+    *       }
+    *     }
+    *   },
+    * "authid": "<assigned authid>",
+    * "authrole": "<assigned auth role>",
+    * "authmethod": "wampcra",
+    *  ...
+    * }
+    */
     const std::unordered_map<std::string, msgpack::object>& welcome_details();
 
 private:

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -772,6 +772,7 @@ void wamp_session::process_challenge(wamp_message&& message)
 inline void wamp_session::process_welcome(wamp_message&& message)
 {
     m_session_id = message.field<uint64_t>(1);
+    message.field(2).convert(m_welcome_details);
     m_session_join.set_value(m_session_id);
 }
 
@@ -1218,6 +1219,11 @@ inline void wamp_session::send_message(wamp_message&& message, bool session_esta
     }
 
     m_transport->send_message(std::move(message));
+}
+
+inline const std::unordered_map<std::string, msgpack::object>&  wamp_session::welcome_details()
+{
+    return m_welcome_details;
 }
 
 } // namespace autobahn


### PR DESCRIPTION
As per spec draft, `WELCOME` message contains a dictionary with values describing router features as well as router assigned (reassigned) authid and role.  

This is a non-breaking change, that doesn't require changing existing code. Welcome dictionary is accessible via `wamp_session::welcome_details()` 

The alternative approach would be changing the signature of join future to something like:
```
    // Future to be fired when session was joined.
    boost::promise<welcome_message> m_session_join;
```
