### PR TITLE
Fix warnings/errors on latest clang/Xcode 7.3

### DIFF
--- a/autobahn/wamp_event.ipp
+++ b/autobahn/wamp_event.ipp
@@ -178,7 +178,7 @@ inline void wamp_event::set_kw_arguments(const msgpack::object& kw_arguments)
 
 inline void wamp_event::set_details(const msgpack::object& details)
 {
-    m_uri = std::move(value_for_key_or<std::string>(details, "topic", std::string()));
+    m_uri = value_for_key_or<std::string>(details, "topic", std::string());
 }
 
 } // namespace autobahn

--- a/autobahn/wamp_invocation.ipp
+++ b/autobahn/wamp_invocation.ipp
@@ -238,7 +238,7 @@ inline void wamp_invocation_impl::send_result(
     auto message = std::make_shared<wamp_message>(5);
     message->set_field(0, static_cast<int>(message_type::YIELD));
     message->set_field(1, m_request_id);
-    
+
     if (resultType == intermediary)
     {
         message->set_field(2, std::map<std::string, bool>{ {"progress", true} });
@@ -345,7 +345,7 @@ inline void wamp_invocation_impl::set_send_result_fn(send_result_fn&& send_resul
 
 inline void wamp_invocation_impl::set_details(const msgpack::object& details)
 {
-    m_uri = std::move(value_for_key_or<std::string>(details, "procedure", std::string()));
+    m_uri = value_for_key_or<std::string>(details, "procedure", std::string());
     m_progressive_results_expected = value_for_key_or<bool>(details, "receive_progress", false);
 }
 

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -66,7 +66,7 @@ inline wamp_session::wamp_session(
     : m_debug_enabled(debug_enabled)
     , m_io_service(io_service)
     , m_transport()
-    , m_request_id(ATOMIC_VAR_INIT(0))
+    , m_request_id(0)
     , m_session_id(0)
     , m_goodbye_sent(false)
     , m_running(false)
@@ -861,7 +861,7 @@ inline void wamp_session::process_error(wamp_message&& message)
     if (!message.is_field_type(4, msgpack::type::STR)) {
         throw protocol_error("invalid ERROR message - Error must be a string (URI)");
     }
-    auto error = std::move(message.field<std::string>(4));
+    auto error = message.field<std::string>(4);
 
     // Arguments|list
     if (message.size() > 5) {


### PR DESCRIPTION
Prevent copy elision warnings [-Wpessimizing-move] by removing redundant std::move calls 
Also fix warning about obsolete ATOMIC_VAR_INIT, use regular std::atomic constructor