### PR TITLE
refactor boost future macros into common header with ifdefs

### DIFF
--- a/autobahn/boost_config.hpp
+++ b/autobahn/boost_config.hpp
@@ -1,0 +1,12 @@
+// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
+#ifndef BOOST_THREAD_PROVIDES_FUTURE
+#define BOOST_THREAD_PROVIDES_FUTURE
+#endif
+#ifndef BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#endif
+#ifndef BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#endif
+
+#include <boost/thread/future.hpp>

--- a/autobahn/wamp_call.hpp
+++ b/autobahn/wamp_call.hpp
@@ -32,12 +32,7 @@
 #define AUTOBAHN_WAMP_CALL_HPP
 
 #include "wamp_call_result.hpp"
-
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
-#include <boost/thread/future.hpp>
+#include "boost_config.hpp"
 
 #include <msgpack.hpp>
 

--- a/autobahn/wamp_rawsocket_transport.hpp
+++ b/autobahn/wamp_rawsocket_transport.hpp
@@ -31,11 +31,7 @@
 #ifndef AUTOBAHN_WAMP_NETWORK_TRANSPORT_HPP
 #define AUTOBAHN_WAMP_NETWORK_TRANSPORT_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
-
+#include "boost_config.hpp"
 #include "wamp_transport.hpp"
 
 #include <boost/thread/future.hpp>

--- a/autobahn/wamp_rawsocket_transport.hpp
+++ b/autobahn/wamp_rawsocket_transport.hpp
@@ -34,7 +34,6 @@
 #include "boost_config.hpp"
 #include "wamp_transport.hpp"
 
-#include <boost/thread/future.hpp>
 #include <boost/asio/io_service.hpp>
 #include <cstddef>
 #include <memory>

--- a/autobahn/wamp_register_request.hpp
+++ b/autobahn/wamp_register_request.hpp
@@ -33,11 +33,8 @@
 
 #include "wamp_procedure.hpp"
 #include "wamp_registration.hpp"
+#include "boost_config.hpp"
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_register_request.hpp
+++ b/autobahn/wamp_register_request.hpp
@@ -35,8 +35,6 @@
 #include "wamp_registration.hpp"
 #include "boost_config.hpp"
 
-#include <boost/thread/future.hpp>
-
 namespace autobahn {
 
 /// An outstanding wamp call.

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -38,11 +38,8 @@
 #include "wamp_procedure.hpp"
 #include "wamp_subscribe_options.hpp"
 #include "wamp_transport_handler.hpp"
+#include "boost_config.hpp"
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 #include <boost/asio.hpp>
 #include <boost/thread/future.hpp>
 #include <cstdint>

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -41,7 +41,6 @@
 #include "boost_config.hpp"
 
 #include <boost/asio.hpp>
-#include <boost/thread/future.hpp>
 #include <cstdint>
 #include <functional>
 #include <istream>

--- a/autobahn/wamp_subscribe_request.hpp
+++ b/autobahn/wamp_subscribe_request.hpp
@@ -33,11 +33,8 @@
 
 #include "wamp_event_handler.hpp"
 #include "wamp_subscription.hpp"
+#include "boost_config.hpp"
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_subscribe_request.hpp
+++ b/autobahn/wamp_subscribe_request.hpp
@@ -35,8 +35,6 @@
 #include "wamp_subscription.hpp"
 #include "boost_config.hpp"
 
-#include <boost/thread/future.hpp>
-
 namespace autobahn {
 
 /// An outstanding wamp call.

--- a/autobahn/wamp_tcp_transport.hpp
+++ b/autobahn/wamp_tcp_transport.hpp
@@ -31,11 +31,7 @@
 #ifndef AUTOBAHN_WAMP_TCP_TRANSPORT_HPP
 #define AUTOBAHN_WAMP_TCP_TRANSPORT_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
-
+#include "boost_config.hpp"
 #include "wamp_rawsocket_transport.hpp"
 
 #include <boost/asio/io_service.hpp>

--- a/autobahn/wamp_transport.hpp
+++ b/autobahn/wamp_transport.hpp
@@ -31,10 +31,7 @@
 #ifndef AUTOBAHN_WAMP_TRANSPORT_HPP
 #define AUTOBAHN_WAMP_TRANSPORT_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#include "boost_config.hpp"
 
 #include <boost/thread/future.hpp>
 #include <memory>

--- a/autobahn/wamp_transport.hpp
+++ b/autobahn/wamp_transport.hpp
@@ -33,7 +33,6 @@
 
 #include "boost_config.hpp"
 
-#include <boost/thread/future.hpp>
 #include <memory>
 #include <string>
 

--- a/autobahn/wamp_transport_handler.hpp
+++ b/autobahn/wamp_transport_handler.hpp
@@ -31,11 +31,7 @@
 #ifndef AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP
 #define AUTOBAHN_WAMP_TRANSPORT_HANDLER_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
-
+#include "boost_config.hpp"
 #include "wamp_message.hpp"
 
 #include <boost/thread/future.hpp>

--- a/autobahn/wamp_transport_handler.hpp
+++ b/autobahn/wamp_transport_handler.hpp
@@ -34,7 +34,6 @@
 #include "boost_config.hpp"
 #include "wamp_message.hpp"
 
-#include <boost/thread/future.hpp>
 #include <memory>
 #include <string>
 

--- a/autobahn/wamp_unsubscribe_request.hpp
+++ b/autobahn/wamp_unsubscribe_request.hpp
@@ -31,10 +31,8 @@
 #ifndef AUTOBAHN_WAMP_UNSUBSCRIBE_REQUEST_HPP
 #define AUTOBAHN_WAMP_UNSUBSCRIBE_REQUEST_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#include "boost_config.hpp"
+
 #include <boost/thread/future.hpp>
 
 namespace autobahn {

--- a/autobahn/wamp_unsubscribe_request.hpp
+++ b/autobahn/wamp_unsubscribe_request.hpp
@@ -33,8 +33,6 @@
 
 #include "boost_config.hpp"
 
-#include <boost/thread/future.hpp>
-
 namespace autobahn {
 
 /// An outstanding wamp call.

--- a/autobahn/wamp_websocket_transport.hpp
+++ b/autobahn/wamp_websocket_transport.hpp
@@ -31,11 +31,7 @@
 #ifndef AUTOBAHN_WEBSOCKET_TRANSPORT_HPP
 #define AUTOBAHN_WEBSOCKET_TRANSPORT_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
-
+#include "boost_config.hpp"
 #include "wamp_transport.hpp"
 
 

--- a/autobahn/wamp_websocket_transport.hpp
+++ b/autobahn/wamp_websocket_transport.hpp
@@ -34,8 +34,6 @@
 #include "boost_config.hpp"
 #include "wamp_transport.hpp"
 
-
-#include <boost/thread/future.hpp>
 #include <boost/asio/io_service.hpp>
 #include <cstddef>
 #include <memory>

--- a/autobahn/wamp_websocketpp_websocket_transport.hpp
+++ b/autobahn/wamp_websocketpp_websocket_transport.hpp
@@ -31,10 +31,7 @@
 #ifndef AUTOBAHN_WEBSOCKETPP_WEBSOCKET_TRANSPORT_HPP
 #define AUTOBAHN_WEBSOCKETPP_WEBSOCKET_TRANSPORT_HPP
 
-// http://stackoverflow.com/questions/22597948/using-boostfuture-with-then-continuations/
-#define BOOST_THREAD_PROVIDES_FUTURE
-#define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#include "boost_config.hpp"
 
 #ifdef _WIN32
 #pragma warning(disable:4996) //Windows XP cancel async IO always fails with operation_not_supported


### PR DESCRIPTION
This consolidates the boost future macros into one place and prevents warnings on windows using ifdefs.