### PR TITLE
Explicit use boost::copy_exception fixes #134

### DIFF
--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -62,7 +62,7 @@ template <class Socket>
 boost::future<void> wamp_rawsocket_transport<Socket>::connect()
 {
     if (m_socket.is_open()) {
-        m_connect.set_exception(network_error("network transport already connected"));
+        m_connect.set_exception(boost::copy_exception(network_error("network transport already connected")));
         return m_connect.get_future();
     }
 
@@ -74,8 +74,8 @@ boost::future<void> wamp_rawsocket_transport<Socket>::connect()
         }
 
         if (error_code) {
-            m_connect.set_exception(
-                            std::system_error(error_code.value(), std::system_category(), "connect"));
+            m_connect.set_exception(boost::copy_exception(
+                            std::system_error(error_code.value(), std::system_category(), "connect")));
             return;
         }
 
@@ -232,8 +232,8 @@ void wamp_rawsocket_transport<Socket>::handshake_reply_handler(
             std::cerr << "rawsocket handshake error: " << error_code << std::endl;
         }
 
-        m_connect.set_exception(
-                std::system_error(error_code.value(), std::system_category(), "async_read"));
+        m_connect.set_exception(boost::copy_exception(
+                std::system_error(error_code.value(), std::system_category(), "async_read")));
         return;
     }
 
@@ -242,7 +242,7 @@ void wamp_rawsocket_transport<Socket>::handshake_reply_handler(
     }
 
     if (m_handshake_buffer[0] != 0x7F) {
-        m_connect.set_exception(protocol_error("invalid handshake frame"));
+        m_connect.set_exception(boost::copy_exception(protocol_error("invalid handshake frame")));
         return;
     }
 
@@ -268,13 +268,13 @@ void wamp_rawsocket_transport<Socket>::handshake_reply_handler(
             error_string << "unknown/reserved error code (" << error << ")";
         }
 
-        m_connect.set_exception(protocol_error(error_string.str()));
+        m_connect.set_exception(boost::copy_exception(protocol_error(error_string.str())));
         return;
     }
 
     uint32_t serializer_type = (m_handshake_buffer[1] & 0x0F);
     if (serializer_type == 0x01) {
-        m_connect.set_exception(protocol_error("json currently not supported"));
+        m_connect.set_exception(boost::copy_exception(protocol_error("json currently not supported")));
     } else if (serializer_type == 0x02) {
         if (m_debug_enabled) {
             std::cerr << "connect successful: valid handshake" << std::endl;
@@ -284,7 +284,7 @@ void wamp_rawsocket_transport<Socket>::handshake_reply_handler(
     } else {
         std::stringstream error_string;
         error_string << "rawsocket handshake error: invalid serializer type (" << serializer_type << ")";
-        m_connect.set_exception(protocol_error(error_string.str()));
+        m_connect.set_exception(boost::copy_exception(protocol_error(error_string.str())));
     }
 }
 

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -89,12 +89,12 @@ inline boost::future<void> wamp_session::start()
         }
 
         if (m_running) {
-            m_session_start.set_exception(protocol_error("session already started"));
+            m_session_start.set_exception(boost::copy_exception(protocol_error("session already started")));
             return;
         }
 
         if (!m_transport) {
-            m_session_start.set_exception(no_transport_error());
+            m_session_start.set_exception(boost::copy_exception(no_transport_error()));
             return;
         }
 
@@ -116,17 +116,17 @@ inline boost::future<void> wamp_session::stop()
         }
 
         if (!m_running) {
-            m_session_stop.set_exception(protocol_error("session already stopped"));
+            m_session_stop.set_exception(boost::copy_exception(protocol_error("session already stopped")));
             return;
         }
 
         if (!m_transport) {
-            m_session_start.set_exception(no_transport_error());
+            m_session_start.set_exception(boost::copy_exception(no_transport_error()));
             return;
         }
 
         if (m_session_id) {
-            m_session_stop.set_exception(protocol_error("session still joined"));
+            m_session_stop.set_exception(boost::copy_exception(protocol_error("session still joined")));
             return;
         }
 
@@ -182,7 +182,7 @@ inline boost::future<uint64_t> wamp_session::join(
         }
 
         if (m_session_id) {
-            m_session_join.set_exception(protocol_error("session already joined"));
+            m_session_join.set_exception(boost::copy_exception(protocol_error("session already joined")));
             return;
         }
 
@@ -212,7 +212,7 @@ inline boost::future<std::string> wamp_session::leave(const std::string& reason)
         }
 
         if (m_goodbye_sent) {
-            m_session_leave.set_exception(protocol_error("goodbye already sent"));
+            m_session_leave.set_exception(boost::copy_exception(protocol_error("goodbye already sent")));
         }
 
         try {
@@ -826,7 +826,7 @@ inline void wamp_session::process_abort(wamp_message&& message)
     }
 
     std::string uri = message.field<std::string>(2);
-    m_session_join.set_exception(abort_error(uri));
+    m_session_join.set_exception(boost::copy_exception(abort_error(uri)));
 }
 
 inline void wamp_session::process_goodbye(wamp_message&& message)
@@ -933,7 +933,7 @@ inline void wamp_session::process_error(wamp_message&& message)
 
                 if (call_itr != m_calls.end()) {
                     // FIXME: Forward all error info.
-                    call_itr->second->result().set_exception(std::runtime_error(error));
+                    call_itr->second->result().set_exception(boost::copy_exception(std::runtime_error(error)));
                     m_calls.erase(call_itr);
                 } else {
                     throw protocol_error("bogus ERROR message for non-pending CALL request ID");

--- a/autobahn/wamp_websocket_transport.ipp
+++ b/autobahn/wamp_websocket_transport.ipp
@@ -55,7 +55,7 @@ inline wamp_websocket_transport::wamp_websocket_transport(
 inline boost::future<void> wamp_websocket_transport::connect()
 {
     if (is_open()) {
-        m_connect.set_exception(network_error("network transport already connected"));
+        m_connect.set_exception(boost::copy_exception(network_error("network transport already connected")));
         return m_connect.get_future();
     }
 

--- a/autobahn/wamp_websocketpp_websocket_transport.ipp
+++ b/autobahn/wamp_websocketpp_websocket_transport.ipp
@@ -90,7 +90,7 @@ namespace autobahn {
     inline void wamp_websocketpp_websocket_transport<Config>::on_ws_fail(websocketpp::connection_hdl hdl) {
         //Log "Connection failed!");
         if (!m_open)
-            m_connect.set_exception(network_error("failed to connect"));
+            m_connect.set_exception(boost::copy_exception(network_error("failed to connect")));
 
         scoped_lock guard(m_lock);
         m_done = true;
@@ -113,7 +113,7 @@ namespace autobahn {
         typename client_type::connection_ptr con = m_client.get_connection(uri, ec);
         if (ec) {
             //Log  "Get Connection Error: " + ec.message());
-            connect_promise.set_exception(websocketpp::lib::system_error(ec.value(), ec.category(), "connect"));
+            connect_promise.set_exception(boost::copy_exception(websocketpp::lib::system_error(ec.value(), ec.category(), "connect")));
             return;
         }
 


### PR DESCRIPTION
Explicit use of boost::copy_exception to fix `error: call of overloaded 'copy_exception(...)' is ambiguous` error.