### PR TITLE
fix compilation for OpenSSL 1.1.x

### DIFF
--- a/autobahn/wamp_auth_utils.hpp
+++ b/autobahn/wamp_auth_utils.hpp
@@ -159,12 +159,13 @@ inline std::string compute_wcs(
     unsigned int len = 32;
     unsigned char hash[32];
 
-    HMAC_CTX hmac;
-    HMAC_CTX_init(&hmac);
-    HMAC_Init_ex(&hmac, key.data(), key.length(), EVP_sha256(), NULL);
-    HMAC_Update(&hmac, ( unsigned char* ) challenge.data(), challenge.length());
-    HMAC_Final(&hmac, hash, &len);
-    HMAC_CTX_cleanup(&hmac);
+    HMAC_CTX *hmac = HMAC_CTX_new();
+    if (!hmac)
+        return "";
+    HMAC_Init_ex(hmac, key.data(), key.length(), EVP_sha256(), NULL);
+    HMAC_Update(hmac, ( unsigned char* ) challenge.data(), challenge.length());
+    HMAC_Final(hmac, hash, &len);
+    HMAC_CTX_free(hmac);
 
 
     std::string str_out;


### PR DESCRIPTION
I had to fix this part of the code for OpenSSL 1.1.x (Debian testing/stretch). The changes are minor, and you might want to add an ifdef for older versions of OpenSSL -or not.