### PR TITLE
Expose details within wamp_invocation_impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+
+# IntelliJ/Clion
+.idea/
+cmake-build-*/

--- a/autobahn/wamp_invocation.hpp
+++ b/autobahn/wamp_invocation.hpp
@@ -192,6 +192,29 @@ public:
     void get_kw_arguments(Map& kw_args) const;
 
     /*!
+     * The details field of the invocation, converted to a map type.
+     *
+     * @tparam Map The map type.
+     *
+     * @return A Map type populated with the details of the invocation.
+     *
+     * @throw std::bad_cast
+     */
+    template <typename Map>
+    Map details() const;
+
+    /*!
+     * Convert and assign the keyword arguments to the given @p details.
+     *
+     * @tparam Map The map type.
+     *
+     * @param details A reference to a Map type object to receive the
+     * invocation details.
+     */
+    template <typename Map>
+    void get_details(Map& details) const;
+
+    /*!
     * Checks if caller expects progressive results.
     */
     bool progressive_results_expected() const;
@@ -274,6 +297,7 @@ private:
 
     msgpack::zone m_zone;
     msgpack::object m_arguments;
+    msgpack::object m_details;
     msgpack::object m_kw_arguments;
     send_result_fn m_send_result_fn;
     std::uint64_t m_request_id;

--- a/autobahn/wamp_invocation.ipp
+++ b/autobahn/wamp_invocation.ipp
@@ -173,6 +173,18 @@ inline void wamp_invocation_impl::get_kw_arguments(Map& kw_args) const
     m_kw_arguments.convert(kw_args);
 }
 
+template <typename Map>
+inline Map wamp_invocation_impl::details() const
+{
+    return m_details.as<Map>();
+}
+
+template <typename Map>
+inline void wamp_invocation_impl::get_details(Map& details) const
+{
+    m_details.convert(details);
+}
+
 inline bool wamp_invocation_impl::progressive_results_expected() const
 {
     return m_progressive_results_expected;
@@ -347,6 +359,7 @@ inline void wamp_invocation_impl::set_details(const msgpack::object& details)
 {
     m_uri = value_for_key_or<std::string>(details, "procedure", std::string());
     m_progressive_results_expected = value_for_key_or<bool>(details, "receive_progress", false);
+    m_details = details;
 }
 
 inline void wamp_invocation_impl::set_request_id(std::uint64_t request_id)


### PR DESCRIPTION
Exposed the details sent with the WAMP invocation so that they may be read by the client hosting the procedure.

They are stored in the wamp_invocation_impl as a msgpack object and exposed as a map, using the same access style as the methods that access the keyword arguments. The details member is set using the set_details method, which also sets the URI and progressive results flag.