### PR TITLE
Add preprocessor rules for OpenSSL < 1.1 compatibility

### DIFF
--- a/autobahn/wamp_auth_utils.hpp
+++ b/autobahn/wamp_auth_utils.hpp
@@ -158,7 +158,14 @@ inline std::string compute_wcs(
 
     unsigned int len = 32;
     unsigned char hash[32];
-
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+    HMAC_CTX hmac;
+    HMAC_CTX_init(&hmac);
+    HMAC_Init_ex(&hmac, key.data(), key.length(), EVP_sha256(), NULL);
+    HMAC_Update(&hmac, (unsigned char*) challenge.data(), challenge.length());
+    HMAC_Final(&hmac, hash, &len);
+    HMAC_CTX_cleanup(&hmac);
+#else
     HMAC_CTX *hmac = HMAC_CTX_new();
     if (!hmac)
         return "";
@@ -166,7 +173,7 @@ inline std::string compute_wcs(
     HMAC_Update(hmac, ( unsigned char* ) challenge.data(), challenge.length());
     HMAC_Final(hmac, hash, &len);
     HMAC_CTX_free(hmac);
-
+#endif
 
     std::string str_out;
     str_out.assign( ( char * ) &hash , 32 );


### PR DESCRIPTION
Added rules to conditionally use the compatible HMAC authentication code based on detected OpenSSL version.

While not strictly anything earth-shattering, a project I'm working on doesn't have anything newer than a (LTS support team) patched version of OpenSSL 1.0.1e. Therefore, updating to the latest Autobahn caused our build to break (ref: [#148](https://github.com/crossbario/autobahn-cpp/pull/148)). Therefore, I added the rules so that others that have the same issue with older versions of OpenSSL being the only ones available can still use the latest Autobahn out of the box.

I didn't test this on a machine that has OpenSSL >= 1.1 as I don't readily have access to one, so someone may want to do that to make sure these changes mesh. If not, I'll see what I can do to grab a few cycles and spin up a VM to test it.