### PR TITLE
Fixed transport connect state detection for WAMP websocket (websocketpp) transport

### DIFF
--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -1320,9 +1320,13 @@ inline void wamp_session::send_message(wamp_message&& message, bool session_esta
         throw protocol_error("session not running");
     }
 
-    if (!m_transport) {
+	if (!m_transport) {
         throw no_transport_error();
     }
+
+	if (!m_transport->is_connected()) {
+		throw no_transport_error();
+	}
 
     if (session_established && !m_session_id) {
         throw no_session_error();

--- a/autobahn/wamp_websocketpp_websocket_transport.hpp
+++ b/autobahn/wamp_websocketpp_websocket_transport.hpp
@@ -72,6 +72,8 @@ namespace autobahn {
 
         virtual ~wamp_websocketpp_websocket_transport() override;
 
+		virtual bool is_connected() const override;
+
     private:
         virtual bool is_open() const override;
         virtual void close() override;

--- a/autobahn/wamp_websocketpp_websocket_transport.ipp
+++ b/autobahn/wamp_websocketpp_websocket_transport.ipp
@@ -70,6 +70,12 @@ namespace autobahn {
         return m_open;
     }
 
+	template <class Config>
+	inline bool wamp_websocketpp_websocket_transport<Config>::is_connected() const
+	{
+		return is_open() && !m_done;
+	}
+
     // The open handler will signal that we are ready to start sending telemetry
     template <class Config>
     inline void wamp_websocketpp_websocket_transport<Config>::on_ws_open(websocketpp::connection_hdl) {


### PR DESCRIPTION
Websocket++ transport appeared to be still connected when it actually was not in some edge cases.
Fixed.