### PR TITLE
Fix undefined behaviour reported by gcc-7.3 sanitize=undefined

### DIFF
--- a/autobahn/wamp_arguments.hpp
+++ b/autobahn/wamp_arguments.hpp
@@ -42,8 +42,10 @@ namespace autobahn {
 using wamp_arguments = std::vector<msgpack::object>;
 using wamp_kw_arguments = std::unordered_map<std::string, msgpack::object>;
 
-static const msgpack::object EMPTY_ARGUMENTS(std::array<msgpack::object, 0>(), nullptr);
-static const msgpack::object EMPTY_KW_ARGUMENTS(wamp_kw_arguments(), nullptr);
+static msgpack::zone EMPTY_ARGUMENTS_ZONE;
+static msgpack::zone EMPTY_KW_ARGUMENTS_ZONE;
+static const msgpack::object EMPTY_ARGUMENTS(std::array<msgpack::object, 0>(), &EMPTY_ARGUMENTS_ZONE);
+static const msgpack::object EMPTY_KW_ARGUMENTS(wamp_kw_arguments(), &EMPTY_KW_ARGUMENTS_ZONE);
 
 
 //msgpack map utilities.  


### PR DESCRIPTION
To replicate run
mkdir build
cd build
CXXFLAGS="-fsanitize=undefined -DMSGPACK_DEFAULT_API_VERSION=1" cmake ..
./examples/caller

You should see

/usr/include/msgpack/v1/object.hpp:636:15: runtime error: reference binding to null pointer of type 'struct zone'
/usr/include/msgpack/v1/object.hpp:636:15: runtime error: reference binding to null pointer of type 'struct zone'

Pass a default zone to the constructors.