### PR TITLE
Add support for current versions of msgpack-c

### DIFF
--- a/autobahn/wamp_arguments.hpp
+++ b/autobahn/wamp_arguments.hpp
@@ -31,8 +31,10 @@
 #ifndef AUTOBAHN_WAMP_ARGUMENTS_HPP
 #define AUTOBAHN_WAMP_ARGUMENTS_HPP
 
+#include <msgpack/object.hpp>
+#include <msgpack/zone.hpp>
+
 #include <array>
-#include <msgpack.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,11 +46,11 @@ using wamp_kw_arguments = std::unordered_map<std::string, msgpack::object>;
 
 static msgpack::zone EMPTY_ARGUMENTS_ZONE;
 static msgpack::zone EMPTY_KW_ARGUMENTS_ZONE;
-static const msgpack::object EMPTY_ARGUMENTS(std::array<msgpack::object, 0>(), &EMPTY_ARGUMENTS_ZONE);
-static const msgpack::object EMPTY_KW_ARGUMENTS(wamp_kw_arguments(), &EMPTY_KW_ARGUMENTS_ZONE);
+static const msgpack::object EMPTY_ARGUMENTS(std::array<msgpack::object, 0>(), EMPTY_ARGUMENTS_ZONE);
+static const msgpack::object EMPTY_KW_ARGUMENTS(wamp_kw_arguments(), EMPTY_KW_ARGUMENTS_ZONE);
 
 
-//msgpack map utilities.  
+//msgpack map utilities.
 //TODO: refactor event & invocation to used these
 template <typename T>
 inline T value_for_key(const msgpack::object& object, const std::string& key)

--- a/autobahn/wamp_call.hpp
+++ b/autobahn/wamp_call.hpp
@@ -34,8 +34,6 @@
 #include "wamp_call_result.hpp"
 #include "boost_config.hpp"
 
-#include <msgpack.hpp>
-
 namespace autobahn {
 
 /// An outstanding wamp call.

--- a/autobahn/wamp_call_result.hpp
+++ b/autobahn/wamp_call_result.hpp
@@ -31,7 +31,9 @@
 #ifndef AUTOBAHN_WAMP_CALL_RESULT_HPP
 #define AUTOBAHN_WAMP_CALL_RESULT_HPP
 
-#include <msgpack.hpp>
+#include <msgpack/zone.hpp>
+#include <msgpack/object.hpp>
+
 #include <string>
 
 namespace autobahn {

--- a/autobahn/wamp_event.hpp
+++ b/autobahn/wamp_event.hpp
@@ -33,8 +33,10 @@
 
 #include "wamp_arguments.hpp"
 
+#include <msgpack/zone.hpp>
+#include <msgpack/object.hpp>
+
 #include <memory>
-#include <msgpack.hpp>
 #include <string>
 
 namespace autobahn {

--- a/autobahn/wamp_invocation.hpp
+++ b/autobahn/wamp_invocation.hpp
@@ -33,10 +33,12 @@
 
 #include "wamp_arguments.hpp"
 
+#include <msgpack/zone.hpp>
+#include <msgpack/object.hpp>
+
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <msgpack.hpp>
 #include <string>
 
 namespace autobahn {

--- a/autobahn/wamp_message.hpp
+++ b/autobahn/wamp_message.hpp
@@ -31,8 +31,10 @@
 #ifndef AUTOBAHN_WAMP_MESSAGE_HPP
 #define AUTOBAHN_WAMP_MESSAGE_HPP
 
+#include <msgpack/zone.hpp>
+#include <msgpack/object.hpp>
+
 #include <cstddef>
-#include <msgpack.hpp>
 #include <vector>
 
 namespace autobahn {

--- a/autobahn/wamp_rawsocket_transport.hpp
+++ b/autobahn/wamp_rawsocket_transport.hpp
@@ -37,7 +37,7 @@
 #include <boost/asio/io_service.hpp>
 #include <cstddef>
 #include <memory>
-#include <msgpack.hpp>
+#include <msgpack/unpack.hpp>
 
 namespace autobahn {
 

--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -352,7 +352,7 @@ void wamp_rawsocket_transport<Socket>::receive_message_body(
         m_message_unpacker.buffer_consumed(m_message_length);
         msgpack::unpacked result;
 
-        while (m_message_unpacker.next(&result)) {
+        while (m_message_unpacker.next(result)) {
             wamp_message::message_fields fields;
             result.get().convert(fields);
 

--- a/autobahn/wamp_session.hpp
+++ b/autobahn/wamp_session.hpp
@@ -42,13 +42,15 @@
 #include "boost_config.hpp"
 
 #include <boost/asio.hpp>
+
+#include <msgpack/object.hpp>
+
 #include <cstdint>
 #include <functional>
 #include <istream>
 #include <ostream>
 #include <map>
 #include <memory>
-#include <msgpack.hpp>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/autobahn/wamp_websocket_transport.ipp
+++ b/autobahn/wamp_websocket_transport.ipp
@@ -87,7 +87,7 @@ inline void wamp_websocket_transport::send_message(wamp_message&& message)
     msgpack::packer<msgpack::sbuffer> packer(*buffer);
     packer.pack(message.fields());
 
-   
+
     // Write actual serialized message.
     write(buffer->data(), buffer->size());
 
@@ -162,7 +162,7 @@ inline void wamp_websocket_transport::receive_message(const std::string& msg)
 
         msgpack::unpacked result;
 
-        while (m_message_unpacker.next(&result)) {
+        while (m_message_unpacker.next(result)) {
             wamp_message::message_fields fields;
             result.get().convert(fields);
 


### PR DESCRIPTION
See [note on MSGPACK_DISABLE_LEGACY_CONVERT](https://github.com/msgpack/msgpack-c/wiki/v1_1_cpp_configure#msgpack_disable_legacy_convert-since-140)
and [release note for version 2.0.0](https://github.com/msgpack/msgpack-c/releases/tag/cpp-2.0.0)