### PR TITLE
Make wamp_event copyable

### DIFF
--- a/autobahn/wamp_event.hpp
+++ b/autobahn/wamp_event.hpp
@@ -41,10 +41,10 @@
 
 namespace autobahn {
 
-class wamp_event
+class wamp_event_impl
 {
 public:
-    wamp_event(msgpack::zone&& zone);
+    wamp_event_impl(msgpack::zone&& zone);
 
 
     //add URI and details
@@ -204,6 +204,8 @@ private:
     std::string m_uri;
 
 };
+
+using wamp_event = std::shared_ptr<wamp_event_impl>;
 
 } // namespace autobahn
 

--- a/autobahn/wamp_event.ipp
+++ b/autobahn/wamp_event.ipp
@@ -34,30 +34,30 @@
 
 namespace autobahn {
 
-inline wamp_event::wamp_event(msgpack::zone&& zone)
+inline wamp_event_impl::wamp_event_impl(msgpack::zone&& zone)
     : m_zone(std::move(zone))
     , m_arguments(EMPTY_ARGUMENTS)
     , m_kw_arguments(EMPTY_KW_ARGUMENTS)
 {
 }
 
-inline const std::string& wamp_event::uri() const
+inline const std::string& wamp_event_impl::uri() const
 {
     return m_uri;
 }
 
-inline std::size_t wamp_event::number_of_arguments() const
+inline std::size_t wamp_event_impl::number_of_arguments() const
 {
     return m_arguments.type == msgpack::type::ARRAY ? m_arguments.via.array.size : 0;
 }
 
-inline std::size_t wamp_event::number_of_kw_arguments() const
+inline std::size_t wamp_event_impl::number_of_kw_arguments() const
 {
     return m_kw_arguments.type == msgpack::type::MAP ? m_kw_arguments.via.map.size : 0;
 }
 
 template <typename T>
-inline T wamp_event::argument(std::size_t index) const
+inline T wamp_event_impl::argument(std::size_t index) const
 {
     if (m_arguments.type != msgpack::type::ARRAY || m_arguments.via.array.size <= index) {
         throw std::out_of_range("no argument at index " + boost::lexical_cast<std::string>(index));
@@ -66,26 +66,26 @@ inline T wamp_event::argument(std::size_t index) const
 }
 
 template <typename List>
-inline List wamp_event::arguments() const
+inline List wamp_event_impl::arguments() const
 {
     return m_arguments.as<List>();
 }
 
 template <typename List>
-inline void wamp_event::get_arguments(List& args) const
+inline void wamp_event_impl::get_arguments(List& args) const
 {
     m_arguments.convert(args);
 }
 
 template <typename... T>
-inline void wamp_event::get_each_argument(T&... args) const
+inline void wamp_event_impl::get_each_argument(T&... args) const
 {
     auto args_tuple = std::make_tuple(std::ref(args)...);
     m_arguments.convert(args_tuple);
 }
 
 template <typename T>
-inline T wamp_event::kw_argument(const std::string& key) const
+inline T wamp_event_impl::kw_argument(const std::string& key) const
 {
     if (m_kw_arguments.type != msgpack::type::MAP) {
         throw msgpack::type_error();
@@ -102,7 +102,7 @@ inline T wamp_event::kw_argument(const std::string& key) const
 }
 
 template <typename T>
-inline T wamp_event::kw_argument(const char* key) const
+inline T wamp_event_impl::kw_argument(const char* key) const
 {
     if (m_kw_arguments.type != msgpack::type::MAP) {
         throw msgpack::type_error();
@@ -120,7 +120,7 @@ inline T wamp_event::kw_argument(const char* key) const
 }
 
 template <typename T>
-inline T wamp_event::kw_argument_or(const std::string& key, const T& fallback) const
+inline T wamp_event_impl::kw_argument_or(const std::string& key, const T& fallback) const
 {
     if (m_kw_arguments.type != msgpack::type::MAP) {
         throw msgpack::type_error();
@@ -137,7 +137,7 @@ inline T wamp_event::kw_argument_or(const std::string& key, const T& fallback) c
 }
 
 template <typename T>
-inline T wamp_event::kw_argument_or(const char* key, const T& fallback) const
+inline T wamp_event_impl::kw_argument_or(const char* key, const T& fallback) const
 {
     if (m_kw_arguments.type != msgpack::type::MAP) {
         throw msgpack::type_error();
@@ -155,28 +155,28 @@ inline T wamp_event::kw_argument_or(const char* key, const T& fallback) const
 }
 
 template <typename Map>
-inline Map wamp_event::kw_arguments() const
+inline Map wamp_event_impl::kw_arguments() const
 {
     return m_kw_arguments.as<Map>();
 }
 
 template <typename Map>
-inline void wamp_event::get_kw_arguments(Map& kw_args) const
+inline void wamp_event_impl::get_kw_arguments(Map& kw_args) const
 {
     m_kw_arguments.convert(kw_args);
 }
 
-inline void wamp_event::set_arguments(const msgpack::object& arguments)
+inline void wamp_event_impl::set_arguments(const msgpack::object& arguments)
 {
     m_arguments = arguments;
 }
 
-inline void wamp_event::set_kw_arguments(const msgpack::object& kw_arguments)
+inline void wamp_event_impl::set_kw_arguments(const msgpack::object& kw_arguments)
 {
     m_kw_arguments = kw_arguments;
 }
 
-inline void wamp_event::set_details(const msgpack::object& details)
+inline void wamp_event_impl::set_details(const msgpack::object& details)
 {
     m_uri = value_for_key_or<std::string>(details, "topic", std::string());
 }

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -1222,21 +1222,21 @@ inline void wamp_session::process_event(wamp_message&& message)
             throw protocol_error("EVENT - Details must be a dictionary");
         }
 
-        wamp_event event(std::move(message.zone()));
+        wamp_event event = std::make_shared<wamp_event_impl>(std::move(message.zone()));
 
-        event.set_details(message.field(3));
+        event->set_details(message.field(3));
 
         if (message.size() > 4) {
             if (!message.is_field_type(4, msgpack::type::ARRAY)) {
                 throw protocol_error("EVENT - EVENT.Arguments must be a list");
             }
-            event.set_arguments(message.field(4));
+            event->set_arguments(message.field(4));
 
             if (message.size() > 5) {
                 if (!message.is_field_type(5, msgpack::type::MAP)) {
                     throw protocol_error("EVENT - EVENT.ArgumentsKw must be a dictionary");
                 }
-                event.set_kw_arguments(message.field(5));
+                event->set_kw_arguments(message.field(5));
             }
         }
 

--- a/examples/subscriber.cpp
+++ b/examples/subscriber.cpp
@@ -38,7 +38,7 @@
 
 void on_topic1(const autobahn::wamp_event& event)
 {
-    std::cerr << "received event: " << event.argument<std::string>(0) << std::endl;
+    std::cerr << "received event: " << event->argument<std::string>(0) << std::endl;
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Sometimes it might be desirable if instances of wamp_event could be copyable, for example when used in conjuction with other 3rd party libraries. The wamp_invocation type already supports this, so the pattern is reused for wamp_event aswell.