### PR TITLE
Fix warning re: implicit `this` lambda capture in C++20 

### DIFF
--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -69,7 +69,7 @@ boost::future<void> wamp_rawsocket_transport<Socket>::connect()
     }
 
     std::weak_ptr<wamp_rawsocket_transport<Socket>> weak_self = this->shared_from_this();
-    auto connect_handler = [=, this](const boost::system::error_code& error_code) {
+    auto connect_handler = [this, weak_self](const boost::system::error_code& error_code) {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -97,7 +97,7 @@ boost::future<void> wamp_rawsocket_transport<Socket>::connect()
                 m_socket,
                 boost::asio::buffer(m_handshake_buffer, sizeof(m_handshake_buffer)));
 
-        auto handshake_reply = [=, this](
+        auto handshake_reply = [this, weak_self](
                 const boost::system::error_code& error,
                 std::size_t bytes_transferred) {
             auto shared_self = weak_self.lock();

--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -69,7 +69,7 @@ boost::future<void> wamp_rawsocket_transport<Socket>::connect()
     }
 
     std::weak_ptr<wamp_rawsocket_transport<Socket>> weak_self = this->shared_from_this();
-    auto connect_handler = [=](const boost::system::error_code& error_code) {
+    auto connect_handler = [=, this](const boost::system::error_code& error_code) {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -97,7 +97,7 @@ boost::future<void> wamp_rawsocket_transport<Socket>::connect()
                 m_socket,
                 boost::asio::buffer(m_handshake_buffer, sizeof(m_handshake_buffer)));
 
-        auto handshake_reply = [=](
+        auto handshake_reply = [=, this](
                 const boost::system::error_code& error,
                 std::size_t bytes_transferred) {
             auto shared_self = weak_self.lock();

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -82,7 +82,7 @@ inline boost::future<void> wamp_session::start()
 {
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -109,7 +109,7 @@ inline boost::future<void> wamp_session::stop()
 {
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -175,7 +175,7 @@ inline boost::future<uint64_t> wamp_session::join(
 
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -205,7 +205,7 @@ inline boost::future<std::string> wamp_session::leave(const std::string& reason)
 
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -241,7 +241,7 @@ inline boost::future<void> wamp_session::publish(const std::string& topic,const 
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -273,7 +273,7 @@ inline boost::future<void> wamp_session::publish(const std::string& topic, const
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -307,7 +307,7 @@ inline boost::future<void> wamp_session::publish(
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -340,7 +340,7 @@ inline boost::future<wamp_subscription> wamp_session::subscribe(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto subscribe_request = std::make_shared<wamp_subscribe_request>(handler);
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -369,7 +369,7 @@ inline boost::future<void> wamp_session::unsubscribe(const wamp_subscription& su
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto unsubscribe_request = std::make_shared<wamp_unsubscribe_request>(subscription);
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -401,7 +401,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -436,7 +436,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -473,7 +473,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -506,7 +506,7 @@ inline boost::future<wamp_registration> wamp_session::provide(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto register_request = std::make_shared<wamp_register_request>(procedure);
 
-    m_io_service.dispatch([=]() {
+    m_io_service.dispatch([=, this]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -535,7 +535,7 @@ inline boost::future<void> wamp_session::unprovide(const wamp_registration& regi
 	auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 	auto unregister_request = std::make_shared<wamp_unregister_request>(registration);
 
-	m_io_service.dispatch([=]() {
+	m_io_service.dispatch([=, this]() {
 		auto shared_self = weak_self.lock();
 		if (!shared_self) {
 			return;
@@ -763,7 +763,7 @@ inline void wamp_session::process_challenge(wamp_message&& message)
     std::shared_ptr< boost::future< void > > context_response = std::make_shared< boost::future<void> >();
 
     // call the context, to get a signature...
-    (*context_response) = on_challenge(challenge_object).then([=]( boost::future<wamp_authenticate> fu_auth) {
+    (*context_response) = on_challenge(challenge_object).then([=, this]( boost::future<wamp_authenticate> fu_auth) {
         try {
             const wamp_authenticate sig = fu_auth.get();
 
@@ -773,7 +773,7 @@ inline void wamp_session::process_challenge(wamp_message&& message)
             message->set_field(2, std::unordered_map<int, int>() /* No Extra/Dict */);
 
             auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
-            m_io_service.dispatch([=]() {
+            m_io_service.dispatch([=, this]() {
                 auto shared_self = weak_self.lock();
                 if (!shared_self) {
                     return;

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -82,7 +82,7 @@ inline boost::future<void> wamp_session::start()
 {
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -109,7 +109,7 @@ inline boost::future<void> wamp_session::stop()
 {
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -175,7 +175,7 @@ inline boost::future<uint64_t> wamp_session::join(
 
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -205,7 +205,7 @@ inline boost::future<std::string> wamp_session::leave(const std::string& reason)
 
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -241,7 +241,7 @@ inline boost::future<void> wamp_session::publish(const std::string& topic,const 
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, result]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -273,7 +273,7 @@ inline boost::future<void> wamp_session::publish(const std::string& topic, const
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, result]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -307,7 +307,7 @@ inline boost::future<void> wamp_session::publish(
     auto result = std::make_shared<boost::promise<void>>();
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, result]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -340,7 +340,7 @@ inline boost::future<wamp_subscription> wamp_session::subscribe(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto subscribe_request = std::make_shared<wamp_subscribe_request>(handler);
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, subscribe_request]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -369,7 +369,7 @@ inline boost::future<void> wamp_session::unsubscribe(const wamp_subscription& su
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto unsubscribe_request = std::make_shared<wamp_unsubscribe_request>(subscription);
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, unsubscribe_request]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -401,7 +401,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, call]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -436,7 +436,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, call]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -473,7 +473,7 @@ inline boost::future<wamp_call_result> wamp_session::call(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto call = std::make_shared<wamp_call>();
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, call]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -506,7 +506,7 @@ inline boost::future<wamp_registration> wamp_session::provide(
     auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
     auto register_request = std::make_shared<wamp_register_request>(procedure);
 
-    m_io_service.dispatch([=, this]() {
+    m_io_service.dispatch([this, weak_self, message, request_id, register_request]() {
         auto shared_self = weak_self.lock();
         if (!shared_self) {
             return;
@@ -535,7 +535,7 @@ inline boost::future<void> wamp_session::unprovide(const wamp_registration& regi
 	auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
 	auto unregister_request = std::make_shared<wamp_unregister_request>(registration);
 
-	m_io_service.dispatch([=, this]() {
+	m_io_service.dispatch([this, weak_self, message, request_id, unregister_request]() {
 		auto shared_self = weak_self.lock();
 		if (!shared_self) {
 			return;
@@ -763,7 +763,7 @@ inline void wamp_session::process_challenge(wamp_message&& message)
     std::shared_ptr< boost::future< void > > context_response = std::make_shared< boost::future<void> >();
 
     // call the context, to get a signature...
-    (*context_response) = on_challenge(challenge_object).then([=, this]( boost::future<wamp_authenticate> fu_auth) {
+    (*context_response) = on_challenge(challenge_object).then([this, context_response]( boost::future<wamp_authenticate> fu_auth) {
         try {
             const wamp_authenticate sig = fu_auth.get();
 
@@ -773,7 +773,7 @@ inline void wamp_session::process_challenge(wamp_message&& message)
             message->set_field(2, std::unordered_map<int, int>() /* No Extra/Dict */);
 
             auto weak_self = std::weak_ptr<wamp_session>(this->shared_from_this());
-            m_io_service.dispatch([=, this]() {
+            m_io_service.dispatch([this, weak_self, message, context_response]() {
                 auto shared_self = weak_self.lock();
                 if (!shared_self) {
                     return;


### PR DESCRIPTION
This fixes the warning in C++20, and remains warning-free on older C++-versions by explicitly specifying all lambda captures. If you were only targeting C++20, you could use [=, this], but that's a warning in older versions. 😢 

`warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]`