### PR TITLE
Fix CMake warning about deprecated quoted variable dereferencing

### DIFF
--- a/cmake/Includes/CMakeLists.txt
+++ b/cmake/Includes/CMakeLists.txt
@@ -10,6 +10,10 @@
 # installations for the respective library. When an explicit library
 # root location hasn't been set, cmake will look in other places.
 
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "-stdlib=libc++ -Wno-unused-local-typedefs -Wno-unknown-warning-option ${CMAKE_CXX_FLAGS}")
     if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
It should be fine to just opt into the new behaviour when it exists as autobahn-cpp doesn't seem to make use of it anyway.
https://cmake.org/cmake/help/latest/policy/CMP0054.html

```
CMake Warning (dev) at build/_deps/autobahn-cpp-src/cmake/Includes/CMakeLists.txt:20 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
```

Another alternative for fixing this would be to bump the cmake_minimum_required from 2.8 to 3.1 (or higher).
https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html