### PR TITLE
Fix -Wextra C++ warnings

### DIFF
--- a/autobahn/wamp_challenge.hpp
+++ b/autobahn/wamp_challenge.hpp
@@ -47,6 +47,8 @@ public:
 
     wamp_challenge( const wamp_challenge & );
 
+    wamp_challenge & operator=( const wamp_challenge & ) = default;
+
     const std::string & challenge() const;
     const std::string & authmethod() const;
     const std::string & salt() const;

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -553,7 +553,7 @@ inline boost::future<void> wamp_session::unprovide(const wamp_registration& regi
 	return unregister_request->response().get_future();
 }
 
-inline boost::future<wamp_authenticate> wamp_session::on_challenge(const wamp_challenge& challenge)
+inline boost::future<wamp_authenticate> wamp_session::on_challenge(const wamp_challenge& /*challenge*/)
 {
     // a dummy implementation
     boost::promise<wamp_authenticate> dummy;
@@ -579,7 +579,7 @@ inline void wamp_session::on_attach(const std::shared_ptr<wamp_transport>& trans
     m_transport = transport;
 }
 
-inline void wamp_session::on_detach(bool was_clean, const std::string& reason)
+inline void wamp_session::on_detach(bool /*was_clean*/, const std::string& /*reason*/)
 {
     // FIXME: We should be deferring this operation to the io service. This
     //        will almost certainly require us to return a future here to

--- a/autobahn/wamp_subscribe_options.hpp
+++ b/autobahn/wamp_subscribe_options.hpp
@@ -50,7 +50,7 @@ public:
 
     const std::string& match() const;
     void set_match(const std::string& match);
-    const bool is_match_set() const;
+    bool is_match_set() const;
 
 private:
     boost::optional<std::string> m_match;

--- a/autobahn/wamp_subscribe_options.ipp
+++ b/autobahn/wamp_subscribe_options.ipp
@@ -51,7 +51,7 @@ inline const std::string& wamp_subscribe_options::match() const
     return *m_match;
 }
 
-inline const bool wamp_subscribe_options::is_match_set() const
+inline bool wamp_subscribe_options::is_match_set() const
 {
     return m_match.is_initialized();
 }
@@ -76,7 +76,7 @@ struct convert<autobahn::wamp_subscribe_options>
 {
     msgpack::object const& operator()(
             msgpack::object const& object,
-            autobahn::wamp_subscribe_options& options) const
+            autobahn::wamp_subscribe_options& /*options*/) const
     {
         return object;
     }


### PR DESCRIPTION
* ignored-qualifiers
* unused-parameter
* deprecated-copy

The only odd one here is this, I suppose:
```
autobahn_cpp-src/autobahn/wamp_session.ipp:753:51: error: implicitly-declared 'autobahn::wamp_challenge& autobahn::wamp_challenge::operator=(const autobahn::wamp_challenge&)' is deprecated [-Werror=deprecated-copy]
  753 |         challenge_object = wamp_challenge("ticket");
```

The other two are just not using arguments to functions or trying in the function declaration to const things returned by value.