### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: ON
+      CTEST_PARALLEL_LEVEL: 2
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-20.04-gcc-10
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "10"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install
+        run: |
+          python -m pip install cmake==3.17.3 --upgrade
+          sudo apt update
+          sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
+          echo "::set-env name=CC::gcc-${{ matrix.version }}"
+          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+
+      - name: Install dependencies
+        run: sudo apt-get install -y libboost-all-dev libmsgpack-dev libwebsocketpp-dev
+
+      - name: Build
+        run: |
+          cmake -S . -B build ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Debug
+          cmake --build build --config Debug


### PR DESCRIPTION
It's mostly set up to support more OSes and compilers because I was originally going to add Clang right away, but it turns out that building boost with clang + libc++ is non-trivial. I can add it and MSVC in a later PR if you don't mind GitHub actions. :)

I use pip to install cmake since that's the most convenient way that works everywhere, and you get newer cmake faster than with apt.

Successful build here: https://github.com/robinlinden/autobahn-cpp/runs/1119335338?check_suite_focus=true