### PR TITLE
Fix link error in provide_prefix with some compilers

### DIFF
--- a/examples/provide_prefix.cpp
+++ b/examples/provide_prefix.cpp
@@ -127,7 +127,8 @@ int main(int argc, char** argv)
                         io.stop();
                         return;
                     }
-                    provide_future = session->provide(PREFIX, &calculator, { { "match", msgpack::object("prefix") } }).then(
+                    msgpack::zone z;
+                    provide_future = session->provide(PREFIX, &calculator, { { "match", msgpack::object("prefix", z) } }).then(
                         [&](boost::future<autobahn::wamp_registration> registration) {
                         try {
                             std::cerr << "registered procedure:" << registration.get().id() << std::endl;


### PR DESCRIPTION
Serializing arrays require providing a zone to msgpack for it to be
happy (sometimes).

My commit adding CI was based on a commit older than the one where I fixed the provide_prefix example not being compiled, so I didn't notice it was broken when I tested things.

I also can't reproduce the linker error locally, but it seems that msgpack always requires a zone when the type you serialize maps to a MAP or ARRAY, and on CI "prefix" mapped to char[7], so that's an array in msgpack, I suppose.

See: https://github.com/msgpack/msgpack-c/wiki/v1_1_cpp_object

The error:
```
/usr/bin/ld: CMakeFiles/provide_prefix.dir/provide_prefix.cpp.o: in function `msgpack::v2::object::object<char [7]>(char const (&) [7])':
/usr/include/msgpack/v2/object_fwd.hpp:36: undefined reference to `void msgpack::v1::operator<< <char, 7ul>(msgpack::v2::object&, char const (&) [7ul])'
```