### PR TITLE
Fix VS2019 warning due to discarding nodiscard value

### DIFF
--- a/autobahn/wamp_auth_utils.hpp
+++ b/autobahn/wamp_auth_utils.hpp
@@ -81,7 +81,7 @@ inline std::string base_64_encode(const std::string & data )
 
     BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
 
-    BIO_write(bio, (const unsigned char *) data.c_str(), data.size());
+    BIO_write(bio, (const unsigned char *) data.c_str(), (int) data.size());
     (void)BIO_flush(bio);
     
     BIO_get_mem_ptr(bio, &pBuf);
@@ -113,10 +113,10 @@ inline std::string derive_key(
         )
 {
 
-    int passwdLen = passwd.size();
+    int passwdLen = (int) passwd.size();
     const char * pwd = passwd.c_str();
 
-    int saltLen = salt.size();
+    int saltLen = (int) salt.size();
     unsigned char * salt_value = (unsigned char * ) salt.c_str();
 
     std::string str_out;
@@ -169,7 +169,7 @@ inline std::string compute_wcs(
     HMAC_CTX *hmac = HMAC_CTX_new();
     if (!hmac)
         return "";
-    HMAC_Init_ex(hmac, key.data(), key.length(), EVP_sha256(), NULL);
+    HMAC_Init_ex(hmac, key.data(), (int) key.length(), EVP_sha256(), NULL);
     HMAC_Update(hmac, ( unsigned char* ) challenge.data(), challenge.length());
     HMAC_Final(hmac, hash, &len);
     HMAC_CTX_free(hmac);

--- a/autobahn/wamp_rawsocket_transport.ipp
+++ b/autobahn/wamp_rawsocket_transport.ipp
@@ -149,7 +149,7 @@ void wamp_rawsocket_transport<Socket>::send_message(wamp_message&& message)
     packer.pack(message.fields());
 
     // Write the length prefix as the message header.
-    uint32_t length = htonl(buffer->size());
+    uint32_t length = htonl((uint32_t) buffer->size());
     boost::asio::write(m_socket, boost::asio::buffer(&length, sizeof(length)));
 
     // Write actual serialized message.

--- a/autobahn/wamp_session.ipp
+++ b/autobahn/wamp_session.ipp
@@ -790,7 +790,7 @@ inline void wamp_session::process_challenge(wamp_message&& message)
             });
 
             // make sure the context_response is copied into this lambda...
-            context_response.get();
+            (void)context_response.get();
         } catch (const std::exception&) {
             if (m_debug_enabled) {
                 std::cerr << "failed to handle authentication" << std::endl;


### PR DESCRIPTION
Normally I'd just delete this since we explicitly copy it into the
lambda anyway, but there are a lot of comments here about that this may
be needed(?)

warning C4834: discarding return value of function with 'nodiscard'
attribute