### PR TITLE
Add support for installing dependencies using a conanfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,13 @@ jobs:
             compiler: gcc
             version: "10"
 
+          - name: ubuntu-20.04-gcc-10-conan
+            os: ubuntu-20.04
+            compiler: gcc
+            version: "10"
+            conan: true
+            cmake-args: -DCMAKE_PREFIX_PATH=`pwd`/build -DCMAKE_MODULE_PATH=`pwd`/build
+
     steps:
       - uses: actions/checkout@v2
 
@@ -29,14 +36,23 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install cmake==3.17.3 --upgrade
+          python -m pip install cmake==3.17.3 conan==1.28.1 --upgrade
           sudo apt update
           sudo apt-get install -y g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
           echo "::set-env name=CC::gcc-${{ matrix.version }}"
           echo "::set-env name=CXX::g++-${{ matrix.version }}"
 
-      - name: Install dependencies
+      - name: Install dependencies (system)
         run: sudo apt-get install -y libboost-all-dev libmsgpack-dev libwebsocketpp-dev
+        if: ${{ !matrix.conan }}
+
+      - name: Install dependencies (conan)
+        run: |
+          conan profile new default --detect --force
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          mkdir -p build && cd build
+          conan install .. --build=missing
+        if: ${{ matrix.conan }}
 
       - name: Build
         run: |

--- a/autobahn/wamp_websocketpp_websocket_transport.ipp
+++ b/autobahn/wamp_websocketpp_websocket_transport.ipp
@@ -48,11 +48,12 @@ namespace autobahn {
     {
         // Bind the handlers we are using
         using websocketpp::lib::placeholders::_1;
+        using websocketpp::lib::placeholders::_2;
         using websocketpp::lib::bind;
         m_client.set_open_handler(bind(&wamp_websocketpp_websocket_transport<Config>::on_ws_open, this, _1));
         m_client.set_close_handler(bind(&wamp_websocketpp_websocket_transport<Config>::on_ws_close, this, _1));
         m_client.set_fail_handler(bind(&wamp_websocketpp_websocket_transport<Config>::on_ws_fail, this, _1));
-        m_client.set_message_handler(bind(&wamp_websocketpp_websocket_transport<Config>::on_ws_message, this, ::_1, ::_2));
+        m_client.set_message_handler(bind(&wamp_websocketpp_websocket_transport<Config>::on_ws_message, this, _1, _2));
         if(!debug_enabled) {
             m_client.clear_access_channels(websocketpp::log::alevel::all);
         }

--- a/cmake/Includes/CMakeLists.txt
+++ b/cmake/Includes/CMakeLists.txt
@@ -53,18 +53,18 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options system thread random)
 
-find_package(Msgpack REQUIRED)
-find_package(Websocketpp REQUIRED)
+find_package(msgpack REQUIRED)
+find_package(websocketpp REQUIRED)
 
 MESSAGE( STATUS "AUTOBAHN_BUILD_EXAMPLES:  " ${AUTOBAHN_BUILD_EXAMPLES} )
 MESSAGE( STATUS "CMAKE_ROOT:               " ${CMAKE_ROOT} )
 MESSAGE( STATUS "CMAKE_INSTALL_PREFIX:     " ${CMAKE_INSTALL_PREFIX} )
 MESSAGE( STATUS "Boost_INCLUDE_DIRS:       " ${Boost_INCLUDE_DIRS} )
 MESSAGE( STATUS "Boost_LIBRARIES:          " ${Boost_LIBRARIES} )
-MESSAGE( STATUS "Msgpack_INCLUDE_DIRS:     " ${Msgpack_INCLUDE_DIRS} )
-MESSAGE( STATUS "Msgpack_LIBRARIES:        " ${Msgpack_LIBRARIES} )
-MESSAGE( STATUS "Websocketpp_INCLUDE_DIRS: " ${Websocketpp_INCLUDE_DIRS} )
-MESSAGE( STATUS "Websocketpp_LIBRARIES:    " ${Websocketpp_LIBRARIES} )
+MESSAGE( STATUS "msgpack_INCLUDE_DIRS:     " ${msgpack_INCLUDE_DIRS} )
+MESSAGE( STATUS "msgpack_LIBRARIES:        " ${msgpack_LIBRARIES} )
+MESSAGE( STATUS "websocketpp_INCLUDE_DIRS: " ${websocketpp_INCLUDE_DIRS} )
+MESSAGE( STATUS "websocketpp_LIBRARIES:    " ${websocketpp_LIBRARIES} )
 
 set(PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/autobahn.hpp
@@ -133,12 +133,14 @@ target_include_directories(autobahn_cpp INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${Boost_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIR}
-    ${Websocketpp_INCLUDE_DIRS}
-    ${Msgpack_INCLUDE_DIRS})
+    ${websocketpp_INCLUDE_DIRS}
+    ${msgpack_INCLUDE_DIRS})
 
 target_link_libraries(autobahn_cpp INTERFACE
     ${Boost_LIBRARIES}
     ${OPENSSL_LIBRARIES}
+    ${websocketpp_LIBRARIES}
+    ${msgpack_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${CMAKE_DL_LIBS})
 

--- a/cmake/Modules/FindMsgpack.cmake
+++ b/cmake/Modules/FindMsgpack.cmake
@@ -1,14 +1,14 @@
 # - Try to find msgpack
 # Once done this will define
-#  Msgpack_FOUND - System has msgpack
-#  Msgpack_INCLUDE_DIRS - The msgpack include directories
+#  msgpack_FOUND - System has msgpack
+#  msgpack_INCLUDE_DIRS - The msgpack include directories
 
 set(_env "$ENV{MSGPACK_ROOT}")
 if(_env)
 
-    set(Msgpack_FOUND TRUE)
-    set(Msgpack_INCLUDE_DIRS "$ENV{MSGPACK_ROOT}/include")
-    set(Msgpack_LIBRARIES "$ENV{MSGPACK_ROOT}/libs")
+    set(msgpack_FOUND TRUE)
+    set(msgpack_INCLUDE_DIRS "$ENV{MSGPACK_ROOT}/include")
+    set(msgpack_LIBRARIES "$ENV{MSGPACK_ROOT}/libs")
 
 else()
 
@@ -18,18 +18,18 @@ else()
         pkg_check_modules(PC_MSGPACK QUIET msgpack)
     endif (PKG_CONFIG_FOUND)
 
-    find_path(Msgpack_INCLUDE_DIR msgpack.hpp
+    find_path(msgpack_INCLUDE_DIR msgpack.hpp
               HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS})
 
-    set(Msgpack_INCLUDE_DIRS ${Msgpack_INCLUDE_DIR})
+    set(msgpack_INCLUDE_DIRS ${msgpack_INCLUDE_DIR})
 
     include(FindPackageHandleStandardArgs)
     # handle the QUIETLY and REQUIRED arguments and set Msgpack_FOUND to TRUE
     # if all listed variables are TRUE
-    find_package_handle_standard_args(Msgpack DEFAULT_MSG
-                                      Msgpack_INCLUDE_DIR
-                                      Msgpack_INCLUDE_DIRS)
+    find_package_handle_standard_args(msgpack DEFAULT_MSG
+                                      msgpack_INCLUDE_DIR
+                                      msgpack_INCLUDE_DIRS)
 
-    mark_as_advanced(Msgpack_INCLUDE_DIR)
+    mark_as_advanced(msgpack_INCLUDE_DIR)
 
 endif()

--- a/cmake/Modules/FindWebsocketpp.cmake
+++ b/cmake/Modules/FindWebsocketpp.cmake
@@ -1,14 +1,14 @@
 # - Try to find websocketpp
 # Once done this will define
-#  Websocketpp_FOUND - System has websocketpp
-#  Websocketpp_INCLUDE_DIRS - The websocketpp include directories
+#  websocketpp_FOUND - System has websocketpp
+#  websocketpp_INCLUDE_DIRS - The websocketpp include directories
 
 set(_env "$ENV{WEBSOCKETPP_ROOT}")
 if(_env)
 
-    set(Websocketpp_FOUND TRUE)
-    set(Websocketpp_INCLUDE_DIRS "$ENV{WEBSOCKETPP_ROOT}/include")
-    set(Websocketpp_LIBRARIES "$ENV{WEBSOCKETPP_ROOT}/libs")
+    set(websocketpp_FOUND TRUE)
+    set(websocketpp_INCLUDE_DIRS "$ENV{WEBSOCKETPP_ROOT}/include")
+    set(websocketpp_LIBRARIES "$ENV{WEBSOCKETPP_ROOT}/libs")
 
 else()
 
@@ -18,18 +18,18 @@ else()
         pkg_check_modules(PC_WEBSOCKETPP QUIET websocketpp)
     endif (PKG_CONFIG_FOUND)
 
-    find_path(Websocketpp_INCLUDE_DIR websocketpp
+    find_path(websocketpp_INCLUDE_DIR websocketpp
               HINTS ${PC_WEBSOCKETPP_INCLUDEDIR} ${PC_WEBSOCKETPP_INCLUDE_DIRS})
 
-    set(Websocketpp_INCLUDE_DIRS ${Websocketpp_INCLUDE_DIR})
+    set(websocketpp_INCLUDE_DIRS ${websocketpp_INCLUDE_DIR})
 
     include(FindPackageHandleStandardArgs)
-    # handle the QUIETLY and REQUIRED arguments and set Websocketpp_FOUND to TRUE
+    # handle the QUIETLY and REQUIRED arguments and set websocketpp_FOUND to TRUE
     # if all listed variables are TRUE
-    find_package_handle_standard_args(Websocketpp DEFAULT_MSG
-                                      Websocketpp_INCLUDE_DIR
-                                      Websocketpp_INCLUDE_DIRS)
+    find_package_handle_standard_args(websocketpp DEFAULT_MSG
+                                      websocketpp_INCLUDE_DIR
+                                      websocketpp_INCLUDE_DIRS)
 
-    mark_as_advanced(Websocketpp_INCLUDE_DIR)
+    mark_as_advanced(websocketpp_INCLUDE_DIR)
 
 endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+boost/1.73.0
+msgpack/3.2.1
+websocketpp/0.8.2
+
+[generators]
+cmake_find_package

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_EXE_LINKER_FLAGS " -static")
 
 add_library(examples_parameters parameters.cpp parameters.hpp)
+target_include_directories(examples_parameters PUBLIC ${Boost_INCLUDE_DIRS})
+target_link_libraries(examples_parameters PRIVATE ${Boost_LIBRARIES})
 
 function(make_example name src)
     add_executable(${name} ${src} ${PUBLIC_HEADERS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(examples_parameters PRIVATE ${Boost_LIBRARIES})
 
 function(make_example name src)
     add_executable(${name} ${src} ${PUBLIC_HEADERS})
-    target_link_libraries(${name} examples_parameters autobahn_cpp ${ARGN})
+    target_link_libraries(${name} examples_parameters autobahn_cpp)
 endfunction()
 
 make_example(caller caller.cpp)
@@ -14,7 +14,7 @@ make_example(callee callee.cpp)
 make_example(provide_prefix provide_prefix.cpp)
 make_example(publisher publisher.cpp)
 make_example(subscriber subscriber.cpp)
-make_example(wampcra wampcra.cpp crypto)
+make_example(wampcra wampcra.cpp)
 make_example(websocket_callee websocket_callee.cpp)
 
 if(UNIX)


### PR DESCRIPTION
This is mainly in preparation of the Windows CI (and to make building and testing autobahn_cpp on systems without everything installed more convenient).

Usage:
```
mkdir -p build && cd build
conan install ..
# Make sure CMake searches in the current for the Findx.cmake-files that inject the conan libraries.
cmake .. -DCMAKE_PREFIX_PATH=`pwd` -DCMAKE_MODULE_PATH=`pwd`
make -j
```

If you don't already have conan installed and set up, you can do so by doing
```
pip install conan
conan profile new default --detect
# You'll probably get weird linker errors if you use new gcc and don't do this.
# At least conan warns you about it.
conan profile update settings.compiler.libcxx=libstdc++11 default
```