### PR TITLE
Add Visual Studio x86 and AMD64 CI builds

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Linux CI
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,50 @@
+name: Windows CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: ON
+      CTEST_PARALLEL_LEVEL: 2
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-2019-cl-x86
+            os: windows-2019
+            generator: Visual Studio 16 2019
+            type: Debug
+            platform: Win32
+            conan_arch: x86
+
+          - name: windows-2019-cl-x64
+            os: windows-2019
+            generator: Visual Studio 16 2019
+            type: Debug
+            platform: x64
+            conan_arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install
+        run: |
+          python -m pip install cmake==3.17.3 conan==1.28.1 --upgrade
+          conan profile new default --detect --force
+          mkdir -p build && cd build
+          conan install .. --build=missing -s arch=${{ matrix.conan_arch }} -s build_type=${{ matrix.type }}
+
+      - name: Build
+        shell: bash # CMake doesn't like paths with backslashes.
+        run: |
+          cmake -S . -B build -G "${{ matrix.generator }}" -A ${{ matrix.platform }} -DCMAKE_PREFIX_PATH=`pwd`/build -DCMAKE_MODULE_PATH=`pwd`/build
+          cmake --build build --config ${{ matrix.type }}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_EXE_LINKER_FLAGS " -static")
 add_library(examples_parameters parameters.cpp parameters.hpp)
 target_include_directories(examples_parameters PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(examples_parameters PRIVATE ${Boost_LIBRARIES})
+target_compile_definitions(examples_parameters PRIVATE ${Boost_DEFINITIONS})
 
 function(make_example name src)
     add_executable(${name} ${src} ${PUBLIC_HEADERS})
@@ -19,4 +20,10 @@ make_example(websocket_callee websocket_callee.cpp)
 
 if(UNIX)
     make_example(uds uds.cpp)
+endif()
+
+# By default MSVC has a 2^16 limit on the number of sections in an object file,
+# and this needs more than that.
+if (MSVC)
+    set_source_files_properties(websocket_callee.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()


### PR DESCRIPTION
I added the Windows jobs in a separate workflow file as it differed too much from the Linux CI to make sense in there.

The new Boost_DEFINITIONS is because Boost has a weird autolink feature (probably something like `#pragma link boostlib.lib` behind a bunch of defines) that assumes that libraries are named in a specific way and that can be disabled by setting a define. Conan places this define in Boost_DEFINITIONS.