### PR TITLE
Add compile def "MSGPACK_DEFAULT_API_VERSION=1"

### DIFF
--- a/cmake/Includes/CMakeLists.txt
+++ b/cmake/Includes/CMakeLists.txt
@@ -57,6 +57,9 @@ endif()
 find_package(Boost REQUIRED COMPONENTS program_options system thread random)
 
 find_package(msgpack REQUIRED)
+# https://github.com/crossbario/autobahn-cpp/issues/95
+add_compile_definitions(MSGPACK_DEFAULT_API_VERSION=1)
+
 find_package(websocketpp REQUIRED)
 
 MESSAGE( STATUS "AUTOBAHN_BUILD_EXAMPLES:  " ${AUTOBAHN_BUILD_EXAMPLES} )


### PR DESCRIPTION
autobahn-cpp only supports msgpack V1. Current libmsgpackc2 & libmsgpack-dev packages on Debian 10 & 11 is using V2 which makes autobahn-cpp incompatible with Debian 10 & 11. Until msgpack V2 support is there, this workaround increases the compatibility on Debian distributions.