### PR TITLE
Fix for current msgpack and websocketpp

### DIFF
--- a/cmake/Includes/CMakeLists.txt
+++ b/cmake/Includes/CMakeLists.txt
@@ -56,8 +56,8 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS program_options system thread random)
 
-find_package(msgpack REQUIRED)
-find_package(websocketpp REQUIRED)
+find_package(Msgpack REQUIRED)
+find_package(Websocketpp REQUIRED)
 
 MESSAGE( STATUS "AUTOBAHN_BUILD_EXAMPLES:  " ${AUTOBAHN_BUILD_EXAMPLES} )
 MESSAGE( STATUS "AUTOBAHN_USE_LIBCXX:      " ${AUTOBAHN_USE_LIBCXX} )
@@ -65,10 +65,10 @@ MESSAGE( STATUS "CMAKE_ROOT:               " ${CMAKE_ROOT} )
 MESSAGE( STATUS "CMAKE_INSTALL_PREFIX:     " ${CMAKE_INSTALL_PREFIX} )
 MESSAGE( STATUS "Boost_INCLUDE_DIRS:       " ${Boost_INCLUDE_DIRS} )
 MESSAGE( STATUS "Boost_LIBRARIES:          " ${Boost_LIBRARIES} )
-MESSAGE( STATUS "msgpack_INCLUDE_DIRS:     " ${msgpack_INCLUDE_DIRS} )
-MESSAGE( STATUS "msgpack_LIBRARIES:        " ${msgpack_LIBRARIES} )
-MESSAGE( STATUS "websocketpp_INCLUDE_DIRS: " ${websocketpp_INCLUDE_DIRS} )
-MESSAGE( STATUS "websocketpp_LIBRARIES:    " ${websocketpp_LIBRARIES} )
+MESSAGE( STATUS "Msgpack_INCLUDE_DIRS:     " ${Msgpack_INCLUDE_DIRS} )
+MESSAGE( STATUS "Msgpack_LIBRARIES:        " ${Msgpack_LIBRARIES} )
+MESSAGE( STATUS "Websocketpp_INCLUDE_DIRS: " ${Websocketpp_INCLUDE_DIRS} )
+MESSAGE( STATUS "Websocketpp_LIBRARIES:    " ${Websocketpp_LIBRARIES} )
 
 set(PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/autobahn/autobahn.hpp
@@ -137,14 +137,14 @@ target_include_directories(autobahn_cpp INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${Boost_INCLUDE_DIRS}
     ${OPENSSL_INCLUDE_DIR}
-    ${websocketpp_INCLUDE_DIRS}
-    ${msgpack_INCLUDE_DIRS})
+    ${Websocketpp_INCLUDE_DIRS}
+    ${Msgpack_INCLUDE_DIRS})
 
 target_link_libraries(autobahn_cpp INTERFACE
     ${Boost_LIBRARIES}
     ${OPENSSL_LIBRARIES}
-    ${websocketpp_LIBRARIES}
-    ${msgpack_LIBRARIES}
+    #${Websocketpp_LIBRARIES}
+    #${Msgpack_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${CMAKE_DL_LIBS})
 

--- a/cmake/Modules/FindMsgpack.cmake
+++ b/cmake/Modules/FindMsgpack.cmake
@@ -1,14 +1,20 @@
 # - Try to find msgpack
 # Once done this will define
-#  msgpack_FOUND - System has msgpack
-#  msgpack_INCLUDE_DIRS - The msgpack include directories
+#  Msgpack_FOUND - System has msgpack
+#  Msgpack_INCLUDE_DIRS - The msgpack include directories
 
 set(_env "$ENV{MSGPACK_ROOT}")
 if(_env)
 
-    set(msgpack_FOUND TRUE)
-    set(msgpack_INCLUDE_DIRS "$ENV{MSGPACK_ROOT}/include")
-    set(msgpack_LIBRARIES "$ENV{MSGPACK_ROOT}/libs")
+    set(Msgpack_FOUND TRUE)
+    set(Msgpack_INCLUDE_DIRS "$ENV{MSGPACK_ROOT}/include")
+    set(Msgpack_LIBRARIES "$ENV{MSGPACK_ROOT}/libs")
+
+elseif(MSGPACK_ROOT)
+
+    set(Msgpack_FOUND TRUE)
+    set(Msgpack_INCLUDE_DIRS "${MSGPACK_ROOT}/include")
+    set(Msgpack_LIBRARIES "${MSGPACK_ROOT}/libs")
 
 else()
 
@@ -18,18 +24,18 @@ else()
         pkg_check_modules(PC_MSGPACK QUIET msgpack)
     endif (PKG_CONFIG_FOUND)
 
-    find_path(msgpack_INCLUDE_DIR msgpack.hpp
+    find_path(Msgpack_INCLUDE_DIR msgpack.hpp
               HINTS ${PC_MSGPACK_INCLUDEDIR} ${PC_MSGPACK_INCLUDE_DIRS})
 
-    set(msgpack_INCLUDE_DIRS ${msgpack_INCLUDE_DIR})
+    set(Msgpack_INCLUDE_DIRS ${Msgpack_INCLUDE_DIR})
 
     include(FindPackageHandleStandardArgs)
     # handle the QUIETLY and REQUIRED arguments and set Msgpack_FOUND to TRUE
     # if all listed variables are TRUE
     find_package_handle_standard_args(msgpack DEFAULT_MSG
-                                      msgpack_INCLUDE_DIR
-                                      msgpack_INCLUDE_DIRS)
+                                      Msgpack_INCLUDE_DIR
+                                      Msgpack_INCLUDE_DIRS)
 
-    mark_as_advanced(msgpack_INCLUDE_DIR)
+    mark_as_advanced(Msgpack_INCLUDE_DIR)
 
 endif()

--- a/cmake/Modules/FindWebsocketpp.cmake
+++ b/cmake/Modules/FindWebsocketpp.cmake
@@ -1,14 +1,20 @@
 # - Try to find websocketpp
 # Once done this will define
-#  websocketpp_FOUND - System has websocketpp
-#  websocketpp_INCLUDE_DIRS - The websocketpp include directories
+#  Websocketpp_FOUND - System has websocketpp
+#  Websocketpp_INCLUDE_DIRS - The websocketpp include directories
 
 set(_env "$ENV{WEBSOCKETPP_ROOT}")
 if(_env)
 
-    set(websocketpp_FOUND TRUE)
-    set(websocketpp_INCLUDE_DIRS "$ENV{WEBSOCKETPP_ROOT}/include")
-    set(websocketpp_LIBRARIES "$ENV{WEBSOCKETPP_ROOT}/libs")
+    set(Websocketpp_FOUND TRUE)
+    set(Websocketpp_INCLUDE_DIRS "$ENV{WEBSOCKETPP_ROOT}/include")
+    set(Websocketpp_LIBRARIES "$ENV{WEBSOCKETPP_ROOT}/libs")
+
+elseif(WEBSOCKETPP_ROOT)
+
+    set(Websocketpp_FOUND TRUE)
+    set(Websocketpp_INCLUDE_DIRS "${WEBSOCKETPP_ROOT}/include")
+    set(Websocketpp_LIBRARIES "${WEBSOCKETPP_ROOT}/libs")
 
 else()
 
@@ -18,18 +24,18 @@ else()
         pkg_check_modules(PC_WEBSOCKETPP QUIET websocketpp)
     endif (PKG_CONFIG_FOUND)
 
-    find_path(websocketpp_INCLUDE_DIR websocketpp
+    find_path(Websocketpp_INCLUDE_DIR websocketpp
               HINTS ${PC_WEBSOCKETPP_INCLUDEDIR} ${PC_WEBSOCKETPP_INCLUDE_DIRS})
 
-    set(websocketpp_INCLUDE_DIRS ${websocketpp_INCLUDE_DIR})
+    set(Websocketpp_INCLUDE_DIRS ${Websocketpp_INCLUDE_DIR})
 
     include(FindPackageHandleStandardArgs)
-    # handle the QUIETLY and REQUIRED arguments and set websocketpp_FOUND to TRUE
+    # handle the QUIETLY and REQUIRED arguments and set Websocketpp_FOUND to TRUE
     # if all listed variables are TRUE
     find_package_handle_standard_args(websocketpp DEFAULT_MSG
-                                      websocketpp_INCLUDE_DIR
-                                      websocketpp_INCLUDE_DIRS)
+                                      Websocketpp_INCLUDE_DIR
+                                      Websocketpp_INCLUDE_DIRS)
 
-    mark_as_advanced(websocketpp_INCLUDE_DIR)
+    mark_as_advanced(Websocketpp_INCLUDE_DIR)
 
 endif()


### PR DESCRIPTION
With this minor patch autobahn-cpp can use the current versions of msgpack and websocketpp easily when adding it to a CMake project